### PR TITLE
Resolve ShellCheck warnings

### DIFF
--- a/buildkite/build-test-push.sh
+++ b/buildkite/build-test-push.sh
@@ -17,11 +17,11 @@ GIT_BRANCH=${GIT_BRANCH//\//-}
 IMAGE_NAME=mrcide/comet
 
 function cleardocker() {
-  $HERE/../scripts/clear-docker.sh
+  "$HERE"/../scripts/clear-docker.sh
 }
 trap cleardocker EXIT
 
-$HERE/../scripts/run-dependencies.sh
+"$HERE"/../scripts/run-dependencies.sh
 
 docker build \
   --build-arg BUILDKITE --build-arg BUILDKITE_BRANCH --build-arg BUILDKITE_BUILD_NUMBER --build-arg BUILDKITE_JOB_ID --build-arg BUILDKITE_BUILD_URL --build-arg BUILDKITE_PROJECT_SLUG --build-arg BUILDKITE_COMMIT --build-arg CODECOV_TOKEN \

--- a/scripts/clear-docker.sh
+++ b/scripts/clear-docker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
-docker kill $(docker ps -aq) || true
-docker rm $(docker ps -aq) || true
+set -eEuo pipefail
+docker kill "$(docker ps -aq)" || true
+docker rm "$(docker ps -aq)" || true
 docker network prune --force || true

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
-set -ex
+set -xeEuo pipefail
 
 docker network prune -f
 
-HERE=$(realpath "$(dirname $0)")
+HERE=$(realpath "$(dirname "$0")")
 NETWORK=comet_nw
 API=cometr
-COMETR_VERSION=$(<$HERE/../src/config/cometr_version)
+COMETR_VERSION=$(<"$HERE"/../src/config/cometr_version)
 
 REGISTRY=mrcide
 
 COMETR_IMAGE=$REGISTRY/$API:$COMETR_VERSION
 
 docker network create $NETWORK
-docker pull $COMETR_IMAGE
-
+docker pull "$COMETR_IMAGE"
 
 docker run --rm -d \
   --network=$NETWORK \
   --name=$API \
   -p 8321:8321 \
-  $COMETR_IMAGE
-
+  "$COMETR_IMAGE"

--- a/scripts/run-dev-dependencies.sh
+++ b/scripts/run-dev-dependencies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -xeEuo pipefail
 
 HERE=$(dirname "$0")
 API=cometr
@@ -7,11 +7,11 @@ NETWORK=comet_nw
 "$HERE"/run-dependencies.sh
 
 # From now on, if the user presses Ctrl+C we should teardown gracefully
-trap cleanup EXIT
 function cleanup() {
   docker kill $API
   docker network rm $NETWORK
 }
+trap cleanup EXIT
 
 # Wait for Ctrl+C
 echo "Ready to use. Press Ctrl+C to teardown."


### PR DESCRIPTION
Good to start a blank slate without any warnings - these changes resolve all linter warnings for our shell scripts (verified via the ShellCheck plugin for IDEA)