### PR TITLE
mrc-2380 Allow editing of standard form parameters

### DIFF
--- a/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
+++ b/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
@@ -51,7 +51,7 @@
                             "type": "number",
                             "min": 0,
                             "max": 100,
-                            "value": 20,
+                            "value": 90,
                             "required": true,
                             "transform": "$/100"
                         }

--- a/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
+++ b/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
@@ -39,7 +39,8 @@
                             "type": "number",
                             "min": 60,
                             "max": 5000,
-                            "value": 1095
+                            "value": 1095,
+                            "required": true
                         }
                     ]
                 },
@@ -80,7 +81,7 @@
                                 {"id": "HCW and Elderly", "label": "HCW and Elderly"},
                                 {"id": "HCW, Elderly and High-Risk Groups", "label": "HCW, Elderly and High-Risk Groups"},
                                 {"id": "Elderly", "label": "Elderly"},
-                                {"id": "No Prioritisation", "label": "No Prioritisation"}
+                                {"id": "All", "label": "No Prioritisation"}
                             ],
                             "value": "HCW and Elderly",
                             "required": true

--- a/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
+++ b/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
@@ -95,7 +95,7 @@
                             "type": "number",
                             "min": 0,
                             "max": 99,
-                            "value": 80,
+                            "value": 20,
                             "required": true,
                             "transform": "$/100"
                         }

--- a/src/app/static/.eslintrc.js
+++ b/src/app/static/.eslintrc.js
@@ -18,7 +18,8 @@ module.exports = {
         indent: ["error", 4],
         quotes: ["error", "double", { avoidEscape: true }],
         "arrow-body-style": "off",
-        "import/prefer-default-export": "off"
+        "import/prefer-default-export": "off",
+        "@typescript-eslint/no-non-null-assertion": "off"
     },
     overrides: [{
         files: [

--- a/src/app/static/src/App.vue
+++ b/src/app/static/src/App.vue
@@ -31,6 +31,7 @@
 
 body {
     padding-top: 5rem;
+    background-color: #eee;
 }
 
 @media only screen and (min-width : 1200px) {

--- a/src/app/static/src/App.vue
+++ b/src/app/static/src/App.vue
@@ -25,9 +25,9 @@
 </template>
 
 <style lang="scss">
-@import 'assets/custom.scss';
 @import '../node_modules/bootstrap/scss/bootstrap.scss';
 @import '../node_modules/bootstrap-vue/src/index.scss';
+@import 'assets/custom.scss';
 
 body {
     padding-top: 5rem;

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -43,13 +43,12 @@ $theme-blue: #003e74;
   top: 0;
   width: 100%;
   height: 100vh;
-  z-index: 9999;
 }
 
 #fetching-results-msg {
   margin-left: auto;
   margin-right: auto;
-  margin-top: 1rem;
+  margin-top: 5rem;
   width: 14rem;
   background: white;
   padding: 1rem;

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -1,4 +1,5 @@
 $body-bg: #eee;
+$theme-blue: #003e74;
 
 .dynamic-form {
   h3 {
@@ -30,6 +31,10 @@ $body-bg: #eee;
     background-color: #fafafa;
     padding-left: 1rem;
   }
+}
+
+.btn-action {
+  @include button-variant($theme-blue, darken($theme-blue, 10%))
 }
 
 

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -1,4 +1,3 @@
-$body-bg: #eee;
 $theme-blue: #003e74;
 
 .dynamic-form {

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -37,4 +37,23 @@ $theme-blue: #003e74;
   @include button-variant($theme-blue, darken($theme-blue, 10%))
 }
 
+#fetching-results {
+  background-color: rgba(0,0,0,0.2);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100vh;
+  z-index: 9999;
+}
+
+#fetching-results-msg {
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 1rem;
+  width: 12.8rem;
+  background: white;
+  padding: 1rem;
+}
+
 

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -51,7 +51,7 @@ $theme-blue: #003e74;
   margin-left: auto;
   margin-right: auto;
   margin-top: 1rem;
-  width: 12.8rem;
+  width: 14rem;
   background: white;
   padding: 1rem;
 }

--- a/src/app/static/src/components/LoadingSpinner.vue
+++ b/src/app/static/src/components/LoadingSpinner.vue
@@ -1,13 +1,102 @@
 <template>
-    $END$
+  <svg class="lds-spin" :class="size" :width="height" :height="height"
+       xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100"
+       preserveAspectRatio="xMidYMid" style="background: none;">
+    <g transform="translate(80,50)">
+      <g transform="rotate(0)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="1" :transform="transforms[0]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.875s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.875s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(71.21320343559643,71.21320343559643)">
+      <g transform="rotate(45)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.875" :transform="transforms[1]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.75s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.75s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(50,80)">
+      <g transform="rotate(90)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.75" :transform="transforms[2]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.625s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.625s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(28.786796564403577,71.21320343559643)">
+      <g transform="rotate(135)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.625" :transform="transforms[3]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.5s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.5s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(20,50.00000000000001)">
+      <g transform="rotate(180)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.5" :transform="transforms[4]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.375s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.375s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(28.78679656440357,28.786796564403577)">
+      <g transform="rotate(225)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.375" :transform="transforms[5]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.25s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.25s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(49.99999999999999,20)">
+      <g transform="rotate(270)">
+        <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.25" :transform="transforms[6]">
+          <animateTransform attributeName="transform" type="scale" begin="-0.125s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="-0.125s"></animate>
+        </circle>
+      </g>
+    </g>
+    <g transform="translate(71.21320343559643,28.78679656440357)">
+      <g transform="rotate(315)">
+        <circle cx="0" cy="0" r="7" fill="#003e74;" fill-opacity="0.125" :transform="transforms[7]">
+          <animateTransform attributeName="transform" type="scale" begin="0s" values="1.1 1.1;1 1"
+                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
+                   begin="0s"></animate>
+        </circle>
+      </g>
+    </g>
+  </svg>
 </template>
-
-<script>
-    export default {
-        name: "LoadingSpinner"
+<script lang="ts">
+import Vue from "vue";
+export default Vue.extend({
+    props: ["size"],
+    computed: {
+        height() {
+            return this.size == "xs" ? "40px" : (this.size == "sm") ? "100px" : "200px";
+        },
+        transforms() {
+            const scales = this.size == "xs" ? [1.01585, 1.02835, 1.04085, 1.05335, 1.06585, 1.07853, 1.09085, 1.00335]
+                : [1.01254, 1.02504, 1.03754, 1.05004, 1.06254, 1.07504, 1.08754, 1.00004];
+            return scales.map(s => `scale(${s}, ${s})`);
+        }
     }
+});
 </script>
-
-<style scoped>
-
-</style>

--- a/src/app/static/src/components/LoadingSpinner.vue
+++ b/src/app/static/src/components/LoadingSpinner.vue
@@ -1,74 +1,81 @@
 <template>
   <svg class="lds-spin" :class="size" :width="height" :height="height"
-       xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100"
-       preserveAspectRatio="xMidYMid" style="background: none;">
+       xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+       viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" style="background: none;">
     <g transform="translate(80,50)">
       <g transform="rotate(0)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="1" :transform="transforms[0]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.875s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.875s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.875s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.875s"></animate>
         </circle>
       </g>
     </g>
     <g transform="translate(71.21320343559643,71.21320343559643)">
       <g transform="rotate(45)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.875" :transform="transforms[1]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.75s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.75s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.75s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.75s"></animate>
         </circle>
       </g>
     </g>
     <g transform="translate(50,80)">
       <g transform="rotate(90)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.75" :transform="transforms[2]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.625s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.625s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.625s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.625s"></animate>
         </circle>
       </g>
     </g>
     <g transform="translate(28.786796564403577,71.21320343559643)">
       <g transform="rotate(135)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.625" :transform="transforms[3]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.5s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.5s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.5s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.5s"></animate>
         </circle>
       </g>
     </g>
     <g transform="translate(20,50.00000000000001)">
       <g transform="rotate(180)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.5" :transform="transforms[4]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.375s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.375s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.375s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.375s"></animate>
         </circle>
       </g>
     </g>
     <g transform="translate(28.78679656440357,28.786796564403577)">
       <g transform="rotate(225)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.375" :transform="transforms[5]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.25s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.25s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.25s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.25s"></animate>
         </circle>
       </g>
     </g>
     <g transform="translate(49.99999999999999,20)">
       <g transform="rotate(270)">
         <circle cx="0" cy="0" r="7" fill="#003e74" fill-opacity="0.25" :transform="transforms[6]">
-          <animateTransform attributeName="transform" type="scale" begin="-0.125s" values="1.1 1.1;1 1"
-                            keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="-0.125s"></animate>
+          <animateTransform attributeName="transform" type="scale" begin="-0.125s"
+                            values="1.1 1.1;1 1" keyTimes="0;1" dur="1s" repeatCount="indefinite">
+          </animateTransform>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="-0.125s"></animate>
         </circle>
       </g>
     </g>
@@ -77,8 +84,8 @@
         <circle cx="0" cy="0" r="7" fill="#003e74;" fill-opacity="0.125" :transform="transforms[7]">
           <animateTransform attributeName="transform" type="scale" begin="0s" values="1.1 1.1;1 1"
                             keyTimes="0;1" dur="1s" repeatCount="indefinite"></animateTransform>
-          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite" values="1;0"
-                   begin="0s"></animate>
+          <animate attributeName="fill-opacity" keyTimes="0;1" dur="1s" repeatCount="indefinite"
+                   values="1;0" begin="0s"></animate>
         </circle>
       </g>
     </g>
@@ -86,16 +93,23 @@
 </template>
 <script lang="ts">
 import Vue from "vue";
+
 export default Vue.extend({
     props: ["size"],
     computed: {
         height() {
-            return this.size == "xs" ? "40px" : (this.size == "sm") ? "100px" : "200px";
+            if (this.size === "xs") {
+                return "40px";
+            }
+            if (this.size === "sm") {
+                return "100px";
+            }
+            return "200px";
         },
         transforms() {
-            const scales = this.size == "xs" ? [1.01585, 1.02835, 1.04085, 1.05335, 1.06585, 1.07853, 1.09085, 1.00335]
+            const scales = this.size === "xs" ? [1.01585, 1.02835, 1.04085, 1.05335, 1.06585, 1.07853, 1.09085, 1.00335]
                 : [1.01254, 1.02504, 1.03754, 1.05004, 1.06254, 1.07504, 1.08754, 1.00004];
-            return scales.map(s => `scale(${s}, ${s})`);
+            return scales.map((s) => `scale(${s}, ${s})`);
         }
     }
 });

--- a/src/app/static/src/components/LoadingSpinner.vue
+++ b/src/app/static/src/components/LoadingSpinner.vue
@@ -1,0 +1,13 @@
+<template>
+    $END$
+</template>
+
+<script>
+    export default {
+        name: "LoadingSpinner"
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/src/app/static/src/components/Modal.vue
+++ b/src/app/static/src/components/Modal.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <div v-if="open" class="modal-backdrop fade show"></div>
+    <div class="modal" :class="{show: open}" :style="style">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-body">
+            <slot></slot>
+          </div>
+          <div class="modal-footer" v-if="$slots['footer']">
+            <slot name="footer"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+import Vue from "vue";
+
+export default Vue.extend({
+    name: "Modal",
+    props: ["open"],
+    computed: {
+        style() {
+            return { display: this.open ? "block" : "none" };
+        }
+    }
+});
+</script>

--- a/src/app/static/src/components/parameters/EditParameters.vue
+++ b/src/app/static/src/components/parameters/EditParameters.vue
@@ -1,0 +1,80 @@
+<template>
+<div>
+  <modal :open="open">
+    <dynamic-form
+      v-if="open"
+      ref="form"
+      v-model="formMeta"
+      :include-submit-button="false"
+      @submit="formSubmitted"
+    ></dynamic-form>
+    <template v-slot:footer>
+      <button class="btn btn-action"
+              @click="updateParameters">OK</button>
+      <button class="btn btn-secondary"
+              @click="$emit('cancel')">Cancel</button>
+    </template>
+  </modal>
+</div>
+</template>
+
+<script lang="ts">
+    import {computed, defineComponent, Ref, ref} from "@vue/composition-api";
+import { DynamicForm, DynamicFormMeta, DynamicFormData } from "@reside-ic/vue-dynamic-form";
+import Modal from "@/components/Modal.vue";
+import { ParameterGroupMetadata } from "@/types";
+
+interface Props {
+    open: boolean;
+    paramGroup: ParameterGroupMetadata
+}
+
+export default defineComponent({
+    name: "EditParameters",
+    props: {
+        open: Boolean,
+        paramGroup: Object
+    },
+    components: {
+        Modal,
+        DynamicForm
+    },
+    setup(props: Props, context) {
+        const form = ref(null);
+        const formMetaInternal: Ref<DynamicFormMeta | null> = ref(null);
+
+        const formMeta = computed({
+            get: () => {
+                return formMetaInternal.value || props.paramGroup.config as DynamicFormMeta;
+            },
+            set: (newValue) => {
+                // Edits to the form are provisional until submitted (may be cancelled) -
+                // keep updated metadata but do not emit updated event until submission
+                formMetaInternal.value = newValue;
+            }
+        });
+
+        function updateParameters() {
+            (form.value as any).submit();
+        }
+
+        function formSubmitted(newValues: DynamicFormData) {
+            if (formMetaInternal.value) {
+                const newParamGroup = { ...props.paramGroup, config: formMetaInternal.value };
+                context.emit("update", newParamGroup, newValues);
+                formMetaInternal.value = null; // update from prop on next open
+            } else {
+                context.emit("cancel"); // OK pressed with no values changed
+            }
+        }
+
+        return {
+            form,
+            formMetaInternal,
+            formMeta,
+            updateParameters,
+            formSubmitted
+        };
+    }
+});
+</script>

--- a/src/app/static/src/components/parameters/EditParameters.vue
+++ b/src/app/static/src/components/parameters/EditParameters.vue
@@ -7,9 +7,11 @@
       v-model="formMeta"
       :include-submit-button="false"
       @submit="formSubmitted"
+      @validate="formValidated"
     ></dynamic-form>
     <template v-slot:footer>
       <button class="btn btn-action"
+              :disabled="!valid"
               @click="updateParameters">OK</button>
       <button class="btn btn-secondary"
               @click="cancel">Cancel</button>
@@ -47,6 +49,7 @@ export default defineComponent({
     setup(props: Props, context) {
         const form: Ref<HTMLFormElement | null> = ref(null);
         const formMetaInternal: Ref<DynamicFormMeta | null> = ref(null);
+        const valid = ref(false);
 
         const formMeta = computed({
             get: () => {
@@ -68,6 +71,10 @@ export default defineComponent({
             formMetaInternal.value = null;
         }
 
+        function formValidated(formValid: boolean) {
+            valid.value = formValid;
+        }
+
         function formSubmitted(newValues: DynamicFormData) {
             if (formMetaInternal.value) {
                 const newParamGroup = { ...props.paramGroup, config: formMetaInternal.value };
@@ -82,8 +89,10 @@ export default defineComponent({
             form,
             formMetaInternal,
             formMeta,
+            valid,
             cancel,
             updateParameters,
+            formValidated,
             formSubmitted
         };
     }

--- a/src/app/static/src/components/parameters/EditParameters.vue
+++ b/src/app/static/src/components/parameters/EditParameters.vue
@@ -12,14 +12,14 @@
       <button class="btn btn-action"
               @click="updateParameters">OK</button>
       <button class="btn btn-secondary"
-              @click="$emit('cancel')">Cancel</button>
+              @click="cancel">Cancel</button>
     </template>
   </modal>
 </div>
 </template>
 
 <script lang="ts">
-    import {computed, defineComponent, Ref, ref} from "@vue/composition-api";
+import { computed, defineComponent, Ref, ref } from "@vue/composition-api";
 import { DynamicForm, DynamicFormMeta, DynamicFormData } from "@reside-ic/vue-dynamic-form";
 import Modal from "@/components/Modal.vue";
 import { ParameterGroupMetadata } from "@/types";
@@ -58,13 +58,18 @@ export default defineComponent({
             (form.value as any).submit();
         }
 
+        function cancel() {
+            context.emit("cancel");
+            formMetaInternal.value = null;
+        }
+
         function formSubmitted(newValues: DynamicFormData) {
             if (formMetaInternal.value) {
                 const newParamGroup = { ...props.paramGroup, config: formMetaInternal.value };
                 context.emit("update", newParamGroup, newValues);
                 formMetaInternal.value = null; // update from prop on next open
             } else {
-                context.emit("cancel"); // OK pressed with no values changed
+                cancel();
             }
         }
 
@@ -72,6 +77,7 @@ export default defineComponent({
             form,
             formMetaInternal,
             formMeta,
+            cancel,
             updateParameters,
             formSubmitted
         };

--- a/src/app/static/src/components/parameters/EditParameters.vue
+++ b/src/app/static/src/components/parameters/EditParameters.vue
@@ -19,7 +19,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, Ref, ref } from "@vue/composition-api";
+import {
+    computed,
+    defineComponent,
+    Ref,
+    ref
+} from "@vue/composition-api";
 import { DynamicForm, DynamicFormMeta, DynamicFormData } from "@reside-ic/vue-dynamic-form";
 import Modal from "@/components/Modal.vue";
 import { ParameterGroupMetadata } from "@/types";
@@ -40,7 +45,7 @@ export default defineComponent({
         DynamicForm
     },
     setup(props: Props, context) {
-        const form = ref(null);
+        const form: Ref<HTMLFormElement | null> = ref(null);
         const formMetaInternal: Ref<DynamicFormMeta | null> = ref(null);
 
         const formMeta = computed({
@@ -55,7 +60,7 @@ export default defineComponent({
         });
 
         function updateParameters() {
-            (form.value as any).submit();
+            (form.value as HTMLFormElement).submit();
         }
 
         function cancel() {

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -88,7 +88,10 @@ export default defineComponent({
             editParamGroupId.value = "";
         }
 
-        function updateParameters(newParamGroup: ParameterGroupMetadata, newValues: DynamicFormData) {
+        function updateParameters(
+            newParamGroup: ParameterGroupMetadata,
+            newValues: DynamicFormData
+        ) {
             closeModal();
 
             const groupId = newParamGroup.id;
@@ -99,7 +102,10 @@ export default defineComponent({
 
             const newParamValues = { ...props.paramValues };
             // Retain any values which are not currently editable e.g. vaccination/future
-            newParamValues[groupId] = { ...(props.paramValues[groupId] as Record<string, unknown>), ...newValues };
+            newParamValues[groupId] = {
+                ...(props.paramValues[groupId] as Record<string, unknown>),
+                ...newValues
+            };
             context.emit("updateValues", newParamValues);
         }
 

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,31 +1,50 @@
 <template>
   <div>
     <div v-for="paramGroup in readOnlyParamGroups" :key="paramGroup.id">
-      <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
+      <div v-if="paramGroup.type == 'dynamicForm'" class="clearfix">
+        <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
                     v-model="paramGroup.config"
                     :readonly="true"></dynamic-form>
+        <button class="btn btn-action float-right mb-3"
+                @click="editParameters(paramGroup.id)">Edit</button>
+      </div>
     </div>
+    <edit-parameters
+      :open="modalOpen"
+      :paramGroup="editParamGroup"
+      @cancel="closeModal"
+      @update="updateParameters"
+    ></edit-parameters>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from "@vue/composition-api";
-import { DynamicControlSection, DynamicForm, DynamicFormMeta } from "@reside-ic/vue-dynamic-form";
-import { ParameterGroupMetadata } from "@/types";
+import { computed, defineComponent, ref } from "@vue/composition-api";
+import {
+    DynamicControlSection,
+    DynamicForm,
+    DynamicFormData,
+    DynamicFormMeta
+} from "@reside-ic/vue-dynamic-form";
+import { Data, ParameterGroupMetadata } from "@/types";
+import EditParameters from "./EditParameters.vue";
 
 interface Props {
     paramGroupMetadata: Array<ParameterGroupMetadata>
+    paramValues: Data
 }
 
 export default defineComponent({
     name: "Parameters",
     components: {
-        DynamicForm
+        DynamicForm,
+        EditParameters
     },
     props: {
-        paramGroupMetadata: Array
+        paramGroupMetadata: Array,
+        paramValues: Object
     },
-    setup(props: Props) {
+    setup(props: Props, context) {
         // Display readonly parameters as collapsible panels
         const collapseSections = (config: DynamicFormMeta) => {
             return config.controlSections.map((section: DynamicControlSection) => {
@@ -52,7 +71,47 @@ export default defineComponent({
             });
         });
 
-        return { readOnlyParamGroups };
+        const modalOpen = ref(false);
+        const editParamGroupId = ref("");
+
+        const editParamGroup = computed(() => {
+            return props.paramGroupMetadata.find((g) => g.id === editParamGroupId.value);
+        });
+
+        function editParameters(paramGroupId: string) {
+            editParamGroupId.value = paramGroupId;
+            modalOpen.value = true;
+        }
+
+        function closeModal() {
+            modalOpen.value = false;
+            editParamGroupId.value = "";
+        }
+
+        function updateParameters(newParamGroup: ParameterGroupMetadata, newValues: DynamicFormData) {
+            closeModal();
+
+            const groupId = newParamGroup.id;
+            const idx = props.paramGroupMetadata.findIndex((g) => g.id === groupId);
+            const newMetadata = [...props.paramGroupMetadata];
+            newMetadata[idx] = newParamGroup;
+            context.emit("updateMetadata", newMetadata);
+
+            const newParamValues = { ...props.paramValues };
+            // Retain any values which are not currently editable e.g. vaccination/future
+            newParamValues[groupId] = { ...(props.paramValues[groupId] as Record<string, unknown>), ...newValues };
+            context.emit("updateValues", newParamValues);
+        }
+
+        return {
+            readOnlyParamGroups,
+            modalOpen,
+            editParamGroupId,
+            editParamGroup,
+            editParameters,
+            closeModal,
+            updateParameters
+        };
     }
 });
 </script>

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -23,5 +23,9 @@ export const actions: ActionTree<RootState, RootState> = {
     async getResults({ commit, state }) {
         const { data } = await axios.post("/results", state.paramValues);
         commit("setResults", data.data);
+    },
+    async updateParameterValues({ commit, dispatch }, newValues) {
+        commit("setParameterValues", newValues);
+        dispatch("getResults");
     }
 };

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -21,8 +21,10 @@ export const actions: ActionTree<RootState, RootState> = {
         commit("setMetadata", data.data);
     },
     async getResults({ commit, state }) {
+        commit("setFetchingResults", true);
         const { data } = await axios.post("/results", state.paramValues);
         commit("setResults", data.data);
+        commit("setFetchingResults", false);
     },
     async updateParameterValues({ commit, dispatch }, newValues) {
         commit("setParameterValues", newValues);

--- a/src/app/static/src/store/index.ts
+++ b/src/app/static/src/store/index.ts
@@ -56,7 +56,7 @@ export default new Vuex.Store<RootState>({
                 forecastDays: 730
             }
         },
-      fetchingResults: false
+        fetchingResults: false
     },
     getters,
     mutations,

--- a/src/app/static/src/store/index.ts
+++ b/src/app/static/src/store/index.ts
@@ -55,7 +55,8 @@ export default new Vuex.Store<RootState>({
             simulation: {
                 forecastDays: 730
             }
-        }
+        },
+      fetchingResults: false
     },
     getters,
     mutations,

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -1,5 +1,10 @@
 import { RootState } from "@/store/state";
-import {ApiInfo, Metadata, Data, ParameterGroupMetadata} from "@/types";
+import {
+    ApiInfo,
+    Metadata,
+    Data,
+    ParameterGroupMetadata
+} from "@/types";
 
 export const mutations = {
     setApiInfo(state: RootState, apiInfo: ApiInfo): void {
@@ -12,7 +17,7 @@ export const mutations = {
         state.results = results;
     },
     setParameterMetadata(state: RootState, paramMetadata: Array<ParameterGroupMetadata>): void {
-        state.metadata!!.parameterGroups = paramMetadata;
+        state.metadata!.parameterGroups = paramMetadata;
     },
     setParameterValues(state: RootState, paramValues: Data): void {
         state.paramValues = paramValues;

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -16,5 +16,8 @@ export const mutations = {
     },
     setParameterValues(state: RootState, paramValues: Data): void {
         state.paramValues = paramValues;
+    },
+    setFetchingResults(state: RootState, fetchingResults: boolean): void {
+        state.fetchingResults = fetchingResults;
     }
 };

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -1,5 +1,5 @@
 import { RootState } from "@/store/state";
-import { ApiInfo, Metadata, Data } from "@/types";
+import {ApiInfo, Metadata, Data, ParameterGroupMetadata} from "@/types";
 
 export const mutations = {
     setApiInfo(state: RootState, apiInfo: ApiInfo): void {
@@ -10,5 +10,11 @@ export const mutations = {
     },
     setResults(state: RootState, results: Data): void {
         state.results = results;
+    },
+    setParameterMetadata(state: RootState, paramMetadata: Array<ParameterGroupMetadata>): void {
+        state.metadata!!.parameterGroups = paramMetadata;
+    },
+    setParameterValues(state: RootState, paramValues: Data): void {
+        state.paramValues = paramValues;
     }
 };

--- a/src/app/static/src/store/state.ts
+++ b/src/app/static/src/store/state.ts
@@ -5,4 +5,5 @@ export interface RootState {
   metadata: Metadata | null
   results: Data | null
   paramValues: Data | null
+  fetchingResults: boolean
 }

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="home row">
     <Parameters class="col-md-4" v-if="metadata"
-                :paramGroupMetadata="metadata.parameterGroups"></Parameters>
+                :paramGroupMetadata="metadata.parameterGroups"
+                :paramValues="paramValues"
+                @updateMetadata="setParameterMetadata"
+                @updateValues="updateParameterValues"></Parameters>
     <Charts class="col-md-8" v-if="metadata"
             :chart-metadata="metadata.charts"
             :chart-data="results"
@@ -11,12 +14,12 @@
 
 <script lang="ts">
 
-import { defineComponent } from "@vue/composition-api";
+import Vue from "vue";
 import Charts from "@/components/charts/Charts.vue";
 import Parameters from "@/components/parameters/Parameters.vue";
-import { mapActions, mapGetters, mapState } from "vuex";
+import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
 
-export default defineComponent({
+export default Vue.extend({
     name: "Home",
     components: {
         Charts,
@@ -25,6 +28,7 @@ export default defineComponent({
     computed: {
         ...mapState([
             "metadata",
+            "paramValues",
             "results"
         ]),
         ...mapGetters([
@@ -34,7 +38,11 @@ export default defineComponent({
     methods: {
         ...mapActions([
             "getMetadata",
-            "getResults"
+            "getResults",
+            "updateParameterValues"
+        ]),
+        ...mapMutations([
+            "setParameterMetadata"
         ])
     },
     mounted() {

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -13,7 +13,7 @@
       <div v-if="fetchingResults" id="fetching-results">
         <div id="fetching-results-msg">
           <loading-spinner size="xs"></loading-spinner>
-          Fetching results...
+          Updating analysis...
         </div>
       </div>
     </div>
@@ -21,14 +21,13 @@
 </template>
 
 <script lang="ts">
-
-import Vue from "vue";
+import {defineComponent} from "@vue/composition-api";
 import Charts from "@/components/charts/Charts.vue";
 import Parameters from "@/components/parameters/Parameters.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
 
-export default Vue.extend({
+export default defineComponent({
     name: "Home",
     components: {
         Charts,

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -6,7 +6,7 @@
                 @updateMetadata="setParameterMetadata"
                 @updateValues="updateParameterValues"></Parameters>
     <div class="col-md-8">
-      <Charts v-if="metadata"
+      <Charts v-if="metadata && !fetchingResults"
               :chart-metadata="metadata.charts"
               :chart-data="results"
               :layout-data="chartLayoutData"></Charts>

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -5,10 +5,18 @@
                 :paramValues="paramValues"
                 @updateMetadata="setParameterMetadata"
                 @updateValues="updateParameterValues"></Parameters>
-    <Charts class="col-md-8" v-if="metadata"
-            :chart-metadata="metadata.charts"
-            :chart-data="results"
-            :layout-data="chartLayoutData"></Charts>
+    <div class="col-md-8">
+      <Charts v-if="metadata"
+              :chart-metadata="metadata.charts"
+              :chart-data="results"
+              :layout-data="chartLayoutData"></Charts>
+      <div v-if="fetchingResults" id="fetching-results">
+        <div id="fetching-results-msg">
+          <loading-spinner size="xs"></loading-spinner>
+          Fetching results...
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -17,19 +25,22 @@
 import Vue from "vue";
 import Charts from "@/components/charts/Charts.vue";
 import Parameters from "@/components/parameters/Parameters.vue";
+import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
 
 export default Vue.extend({
     name: "Home",
     components: {
         Charts,
-        Parameters
+        Parameters,
+        LoadingSpinner
     },
     computed: {
         ...mapState([
             "metadata",
             "paramValues",
-            "results"
+            "results",
+            "fetchingResults"
         ]),
         ...mapGetters([
             "chartLayoutData"

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -21,11 +21,16 @@
 </template>
 
 <script lang="ts">
-import {defineComponent} from "@vue/composition-api";
+import { defineComponent } from "@vue/composition-api";
 import Charts from "@/components/charts/Charts.vue";
 import Parameters from "@/components/parameters/Parameters.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
-import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
+import {
+    mapActions,
+    mapGetters,
+    mapMutations,
+    mapState
+} from "vuex";
 
 export default defineComponent({
     name: "Home",

--- a/src/app/static/tests/mocks.ts
+++ b/src/app/static/tests/mocks.ts
@@ -31,6 +31,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         metadata: null,
         results: null,
         paramValues: null,
+        fetchingResults: false,
         ...state
     };
 }

--- a/src/app/static/tests/unit/components/home.test.ts
+++ b/src/app/static/tests/unit/components/home.test.ts
@@ -81,6 +81,17 @@ describe("Home", () => {
         expect(parameters.exists()).toBe(false);
     });
 
+    it("does not render Charts when fetching results", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                fetchingResults: true
+            })
+        });
+        const wrapper = shallowMount(Home, { store });
+        const charts = wrapper.findComponent(Charts);
+        expect(charts.exists()).toBe(false);
+    });
+
     it("renders fetching results indicator only when fetching results", () => {
         let store = new Vuex.Store<RootState>({ state: mockRootState() });
         let wrapper = shallowMount(Home, { store });

--- a/src/app/static/tests/unit/components/home.test.ts
+++ b/src/app/static/tests/unit/components/home.test.ts
@@ -1,6 +1,4 @@
 // Mock the import of plotly to avoid import failures in non-browser context
-import LoadingSpinner from "@/components/LoadingSpinner.vue";
-
 jest.mock("plotly.js", () => ({
     react: jest.fn()
 }));
@@ -103,7 +101,7 @@ describe("Home", () => {
         const mockSetParameterMetadata = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-              metadata: {} as any,
+                metadata: {} as any
             }),
             mutations: {
                 setParameterMetadata: mockSetParameterMetadata
@@ -111,7 +109,7 @@ describe("Home", () => {
         });
 
         const wrapper = shallowMount(Home, { store });
-        const mockParameterMetadata = [ { id: "grp1" } ];
+        const mockParameterMetadata = [{ id: "grp1" }];
         const parameters = wrapper.findComponent(Parameters);
         parameters.vm.$emit("updateMetadata", mockParameterMetadata);
         await Vue.nextTick();
@@ -123,7 +121,7 @@ describe("Home", () => {
         const mockUpdateParameterValues = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-                metadata: {} as any,
+                metadata: {} as any
             }),
             actions: {
                 updateParameterValues: mockUpdateParameterValues

--- a/src/app/static/tests/unit/components/loadingSpinner.test.ts
+++ b/src/app/static/tests/unit/components/loadingSpinner.test.ts
@@ -1,4 +1,4 @@
-import {mount} from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 
 describe("LoadingSpinner", () => {

--- a/src/app/static/tests/unit/components/loadingSpinner.test.ts
+++ b/src/app/static/tests/unit/components/loadingSpinner.test.ts
@@ -1,0 +1,18 @@
+import {mount} from "@vue/test-utils";
+import LoadingSpinner from "@/components/LoadingSpinner.vue";
+
+describe("LoadingSpinner", () => {
+    it("sets svg size as expected", () => {
+        const defaultSize = mount(LoadingSpinner);
+        expect(defaultSize.find("svg").attributes("height")).toBe("200px");
+        expect(defaultSize.find("svg").attributes("width")).toBe("200px");
+
+        const xs = mount(LoadingSpinner, { propsData: { size: "xs" } });
+        expect(xs.find("svg").attributes("height")).toBe("40px");
+        expect(xs.find("svg").attributes("width")).toBe("40px");
+
+        const sm = mount(LoadingSpinner, { propsData: { size: "sm" } });
+        expect(sm.find("svg").attributes("height")).toBe("100px");
+        expect(sm.find("svg").attributes("width")).toBe("100px");
+    });
+});

--- a/src/app/static/tests/unit/components/modal.test.ts
+++ b/src/app/static/tests/unit/components/modal.test.ts
@@ -1,71 +1,66 @@
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import Modal from "@/components/Modal.vue";
 
 describe("modal", () => {
-
-  it("is displayed when open is true", () => {
-
-    const wrapper = shallowMount(Modal, {
-      propsData: {
-        open: true
-      }
-    });
-    expect(wrapper.find(".modal").element.style.display).toBe("block");
-    expect(wrapper.findAll(".modal-backdrop").length).toBe(1);
-  });
-
-  it("is not displayed when open is false", () => {
-
-    const wrapper = shallowMount(Modal, {
-      propsData: {
-        open: false
-      }
+    it("is displayed when open is true", () => {
+        const wrapper = shallowMount(Modal, {
+            propsData: {
+                open: true
+            }
+        });
+        expect(wrapper.find(".modal").element.style.display).toBe("block");
+        expect(wrapper.findAll(".modal-backdrop").length).toBe(1);
     });
 
-    expect(wrapper.find(".modal").element.style.display).toBe("none");
-    expect(wrapper.findAll(".modal-backdrop").length).toBe(0);
-  });
+    it("is not displayed when open is false", () => {
+        const wrapper = shallowMount(Modal, {
+            propsData: {
+                open: false
+            }
+        });
 
-  it("displays child content in body", () => {
-
-    const wrapper = shallowMount(Modal, {
-      propsData: {
-        open: true
-      },
-      slots: {
-        default: "TEST"
-      }
+        expect(wrapper.find(".modal").element.style.display).toBe("none");
+        expect(wrapper.findAll(".modal-backdrop").length).toBe(0);
     });
 
-    expect(wrapper.find(".modal-body").text()).toBe("TEST");
-  });
+    it("displays child content in body", () => {
+        const wrapper = shallowMount(Modal, {
+            propsData: {
+                open: true
+            },
+            slots: {
+                default: "TEST"
+            }
+        });
 
-  it("does not include footer if footer slot is missing", () => {
-    const wrapper = shallowMount(Modal, {
-      propsData: {
-        open: true
-      },
-      slots: {
-        default: "TEST"
-      }
+        expect(wrapper.find(".modal-body").text()).toBe("TEST");
     });
 
-    expect(wrapper.findAll(".modal-footer").length).toBe(0);
-  });
+    it("does not include footer if footer slot is missing", () => {
+        const wrapper = shallowMount(Modal, {
+            propsData: {
+                open: true
+            },
+            slots: {
+                default: "TEST"
+            }
+        });
 
-  it("includes footer slot if provided", () => {
-    const wrapper = shallowMount(Modal, {
-      propsData: {
-        open: true
-      },
-      slots: {
-        default: "TEST",
-        footer: "test-footer"
-      }
+        expect(wrapper.findAll(".modal-footer").length).toBe(0);
     });
 
-    expect(wrapper.findAll(".modal-footer").length).toBe(1);
-    expect(wrapper.find(".modal-footer").text()).toBe("test-footer");
-  });
+    it("includes footer slot if provided", () => {
+        const wrapper = shallowMount(Modal, {
+            propsData: {
+                open: true
+            },
+            slots: {
+                default: "TEST",
+                footer: "test-footer"
+            }
+        });
 
+        expect(wrapper.findAll(".modal-footer").length).toBe(1);
+        expect(wrapper.find(".modal-footer").text()).toBe("test-footer");
+    });
 });

--- a/src/app/static/tests/unit/components/modal.test.ts
+++ b/src/app/static/tests/unit/components/modal.test.ts
@@ -1,0 +1,71 @@
+import {shallowMount} from "@vue/test-utils";
+import Modal from "@/components/Modal.vue";
+
+describe("modal", () => {
+
+  it("is displayed when open is true", () => {
+
+    const wrapper = shallowMount(Modal, {
+      propsData: {
+        open: true
+      }
+    });
+    expect(wrapper.find(".modal").element.style.display).toBe("block");
+    expect(wrapper.findAll(".modal-backdrop").length).toBe(1);
+  });
+
+  it("is not displayed when open is false", () => {
+
+    const wrapper = shallowMount(Modal, {
+      propsData: {
+        open: false
+      }
+    });
+
+    expect(wrapper.find(".modal").element.style.display).toBe("none");
+    expect(wrapper.findAll(".modal-backdrop").length).toBe(0);
+  });
+
+  it("displays child content in body", () => {
+
+    const wrapper = shallowMount(Modal, {
+      propsData: {
+        open: true
+      },
+      slots: {
+        default: "TEST"
+      }
+    });
+
+    expect(wrapper.find(".modal-body").text()).toBe("TEST");
+  });
+
+  it("does not include footer if footer slot is missing", () => {
+    const wrapper = shallowMount(Modal, {
+      propsData: {
+        open: true
+      },
+      slots: {
+        default: "TEST"
+      }
+    });
+
+    expect(wrapper.findAll(".modal-footer").length).toBe(0);
+  });
+
+  it("includes footer slot if provided", () => {
+    const wrapper = shallowMount(Modal, {
+      propsData: {
+        open: true
+      },
+      slots: {
+        default: "TEST",
+        footer: "test-footer"
+      }
+    });
+
+    expect(wrapper.findAll(".modal-footer").length).toBe(1);
+    expect(wrapper.find(".modal-footer").text()).toBe("test-footer");
+  });
+
+});

--- a/src/app/static/tests/unit/components/parameters/editParameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editParameters.test.ts
@@ -1,0 +1,118 @@
+import {mount} from "@vue/test-utils";
+import Vue from "vue";
+import EditParameters from "@/components/parameters/EditParameters.vue";
+import Modal from "@/components/Modal.vue";
+import {DynamicForm} from "@reside-ic/vue-dynamic-form";
+
+describe("EditParameters", () => {
+  const paramGroup = {
+    id: "healthcare",
+    type: "dynamicForm",
+    config: {
+      controlSections: [
+        {
+          label: "Healthcare capacity",
+          controlGroups: [
+            {
+              label: "Total general beds",
+              controls: [
+                {
+                  name: "generalBeds",
+                  type: "number",
+                  value: 314210
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  };
+
+  const modifiedParamGroup = {
+    id: "healthcare",
+    type: "dynamicForm",
+    config: {
+      controlSections: [
+        {
+          label: "Healthcare capacity",
+          controlGroups: [
+            {
+              label: "Total general beds",
+              controls: [
+                {
+                  name: "generalBeds",
+                  type: "number",
+                  value: 1000
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  };
+
+  function getWrapper(open:boolean = true) {
+      const propsData = {open, paramGroup};
+      return mount(EditParameters, { propsData });
+  }
+
+  it("renders as expected", () => {
+      let wrapper = getWrapper();
+      expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+      expect(wrapper.findComponent(Modal).props("open")).toBe(true);
+      expect(wrapper.find(".btn-action").text()).toBe("OK");
+      expect(wrapper.find(".btn-secondary").text()).toBe("Cancel");
+
+      wrapper = getWrapper(false);
+      expect(wrapper.findComponent(DynamicForm).exists()).toBe(false);
+      expect(wrapper.findComponent(Modal).props("open")).toBe(false);
+  });
+
+  it("Emits cancel event when cancel button clicked", async () => {
+      const wrapper = getWrapper();
+      wrapper.find(".btn-secondary").trigger("click");
+      await Vue.nextTick();
+      expect(wrapper.emitted("cancel")!!.length).toBe(1);
+  });
+
+  it("Emits cancel event when OK button clicked with no form changes", async () => {
+      const wrapper = getWrapper();
+      wrapper.find(".btn-action").trigger("click");
+      await Vue.nextTick();
+      expect(wrapper.emitted("cancel")!!.length).toBe(1);
+      expect(wrapper.emitted("update")).toBeUndefined();
+  });
+
+  it("Emits update event when OK button clicked after form change", async (done) => {
+      const wrapper = getWrapper();
+      const input = wrapper.find("input");
+      input.setValue("1000");
+      await Vue.nextTick();
+      wrapper.find(".btn-action").trigger("click");
+      setTimeout(() => {
+          expect(wrapper.emitted("update")!!.length).toBe(1);
+          expect(wrapper.emitted("cancel")).toBeUndefined();
+
+          const updatedParams = wrapper.emitted("update")!![0];
+          expect(updatedParams[0]).toStrictEqual(modifiedParamGroup);
+          expect(updatedParams[1]).toStrictEqual({generalBeds: 1000});
+
+          expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+          done();
+      });
+  });
+
+  it("resets form data when cancel after form change", async () => {
+      const wrapper = getWrapper();
+      const input = wrapper.find("input");
+      input.setValue("1000");
+      await Vue.nextTick();
+      expect(wrapper.findComponent(DynamicForm).props("formMeta")).toStrictEqual(modifiedParamGroup.config);
+
+      wrapper.find(".btn-secondary").trigger("click");
+      await Vue.nextTick();
+      expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+  });
+});

--- a/src/app/static/tests/unit/components/parameters/editParameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editParameters.test.ts
@@ -1,118 +1,118 @@
-import {mount} from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import Vue from "vue";
 import EditParameters from "@/components/parameters/EditParameters.vue";
 import Modal from "@/components/Modal.vue";
-import {DynamicForm} from "@reside-ic/vue-dynamic-form";
+import { DynamicForm } from "@reside-ic/vue-dynamic-form";
 
 describe("EditParameters", () => {
-  const paramGroup = {
-    id: "healthcare",
-    type: "dynamicForm",
-    config: {
-      controlSections: [
-        {
-          label: "Healthcare capacity",
-          controlGroups: [
-            {
-              label: "Total general beds",
-              controls: [
+    const paramGroup = {
+        id: "healthcare",
+        type: "dynamicForm",
+        config: {
+            controlSections: [
                 {
-                  name: "generalBeds",
-                  type: "number",
-                  value: 314210
+                    label: "Healthcare capacity",
+                    controlGroups: [
+                        {
+                            label: "Total general beds",
+                            controls: [
+                                {
+                                    name: "generalBeds",
+                                    type: "number",
+                                    value: 314210
+                                }
+                            ]
+                        }
+                    ]
                 }
-              ]
-            }
-          ]
+            ]
         }
-      ]
-    }
-  };
+    };
 
-  const modifiedParamGroup = {
-    id: "healthcare",
-    type: "dynamicForm",
-    config: {
-      controlSections: [
-        {
-          label: "Healthcare capacity",
-          controlGroups: [
-            {
-              label: "Total general beds",
-              controls: [
+    const modifiedParamGroup = {
+        id: "healthcare",
+        type: "dynamicForm",
+        config: {
+            controlSections: [
                 {
-                  name: "generalBeds",
-                  type: "number",
-                  value: 1000
+                    label: "Healthcare capacity",
+                    controlGroups: [
+                        {
+                            label: "Total general beds",
+                            controls: [
+                                {
+                                    name: "generalBeds",
+                                    type: "number",
+                                    value: 1000
+                                }
+                            ]
+                        }
+                    ]
                 }
-              ]
-            }
-          ]
+            ]
         }
-      ]
+    };
+
+    function getWrapper(open = true) {
+        const propsData = { open, paramGroup };
+        return mount(EditParameters, { propsData });
     }
-  };
 
-  function getWrapper(open:boolean = true) {
-      const propsData = {open, paramGroup};
-      return mount(EditParameters, { propsData });
-  }
+    it("renders as expected", () => {
+        let wrapper = getWrapper();
+        expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+        expect(wrapper.findComponent(Modal).props("open")).toBe(true);
+        expect(wrapper.find(".btn-action").text()).toBe("OK");
+        expect(wrapper.find(".btn-secondary").text()).toBe("Cancel");
 
-  it("renders as expected", () => {
-      let wrapper = getWrapper();
-      expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
-      expect(wrapper.findComponent(Modal).props("open")).toBe(true);
-      expect(wrapper.find(".btn-action").text()).toBe("OK");
-      expect(wrapper.find(".btn-secondary").text()).toBe("Cancel");
+        wrapper = getWrapper(false);
+        expect(wrapper.findComponent(DynamicForm).exists()).toBe(false);
+        expect(wrapper.findComponent(Modal).props("open")).toBe(false);
+    });
 
-      wrapper = getWrapper(false);
-      expect(wrapper.findComponent(DynamicForm).exists()).toBe(false);
-      expect(wrapper.findComponent(Modal).props("open")).toBe(false);
-  });
+    it("Emits cancel event when cancel button clicked", async () => {
+        const wrapper = getWrapper();
+        wrapper.find(".btn-secondary").trigger("click");
+        await Vue.nextTick();
+        expect(wrapper.emitted("cancel")!.length).toBe(1);
+    });
 
-  it("Emits cancel event when cancel button clicked", async () => {
-      const wrapper = getWrapper();
-      wrapper.find(".btn-secondary").trigger("click");
-      await Vue.nextTick();
-      expect(wrapper.emitted("cancel")!!.length).toBe(1);
-  });
+    it("Emits cancel event when OK button clicked with no form changes", async () => {
+        const wrapper = getWrapper();
+        wrapper.find(".btn-action").trigger("click");
+        await Vue.nextTick();
+        expect(wrapper.emitted("cancel")!.length).toBe(1);
+        expect(wrapper.emitted("update")).toBeUndefined();
+    });
 
-  it("Emits cancel event when OK button clicked with no form changes", async () => {
-      const wrapper = getWrapper();
-      wrapper.find(".btn-action").trigger("click");
-      await Vue.nextTick();
-      expect(wrapper.emitted("cancel")!!.length).toBe(1);
-      expect(wrapper.emitted("update")).toBeUndefined();
-  });
+    it("Emits update event when OK button clicked after form change", async (done) => {
+        const wrapper = getWrapper();
+        const input = wrapper.find("input");
+        input.setValue("1000");
+        await Vue.nextTick();
+        wrapper.find(".btn-action").trigger("click");
+        setTimeout(() => {
+            expect(wrapper.emitted("update")!.length).toBe(1);
+            expect(wrapper.emitted("cancel")).toBeUndefined();
 
-  it("Emits update event when OK button clicked after form change", async (done) => {
-      const wrapper = getWrapper();
-      const input = wrapper.find("input");
-      input.setValue("1000");
-      await Vue.nextTick();
-      wrapper.find(".btn-action").trigger("click");
-      setTimeout(() => {
-          expect(wrapper.emitted("update")!!.length).toBe(1);
-          expect(wrapper.emitted("cancel")).toBeUndefined();
+            const updatedParams = wrapper.emitted("update")![0];
+            expect(updatedParams[0]).toStrictEqual(modifiedParamGroup);
+            expect(updatedParams[1]).toStrictEqual({ generalBeds: 1000 });
 
-          const updatedParams = wrapper.emitted("update")!![0];
-          expect(updatedParams[0]).toStrictEqual(modifiedParamGroup);
-          expect(updatedParams[1]).toStrictEqual({generalBeds: 1000});
+            expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+            done();
+        });
+    });
 
-          expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
-          done();
-      });
-  });
+    it("resets form data when cancel after form change", async () => {
+        const wrapper = getWrapper();
+        const input = wrapper.find("input");
+        input.setValue("1000");
+        await Vue.nextTick();
+        expect(wrapper.findComponent(DynamicForm).props("formMeta")).toStrictEqual(modifiedParamGroup.config);
 
-  it("resets form data when cancel after form change", async () => {
-      const wrapper = getWrapper();
-      const input = wrapper.find("input");
-      input.setValue("1000");
-      await Vue.nextTick();
-      expect(wrapper.findComponent(DynamicForm).props("formMeta")).toStrictEqual(modifiedParamGroup.config);
-
-      wrapper.find(".btn-secondary").trigger("click");
-      await Vue.nextTick();
-      expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
-  });
+        wrapper.find(".btn-secondary").trigger("click");
+        await Vue.nextTick();
+        expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+    });
 });

--- a/src/app/static/tests/unit/components/parameters/editParameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editParameters.test.ts
@@ -79,6 +79,8 @@ describe("EditParameters", () => {
 
     it("Emits cancel event when OK button clicked with no form changes", async () => {
         const wrapper = getWrapper();
+        wrapper.setData({ valid: true });
+        await Vue.nextTick();
         wrapper.find(".btn-action").trigger("click");
         await Vue.nextTick();
         expect(wrapper.emitted("cancel")!.length).toBe(1);
@@ -114,5 +116,20 @@ describe("EditParameters", () => {
         wrapper.find(".btn-secondary").trigger("click");
         await Vue.nextTick();
         expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
+    });
+
+    it("updates OK button disabled in response to form validate", async () => {
+        const wrapper = getWrapper();
+        const ok = wrapper.find(".btn-action");
+        expect(ok.attributes("disabled")).toBe("disabled");
+
+        const form = wrapper.findComponent(DynamicForm);
+        form.vm.$emit("validate", true);
+        await Vue.nextTick();
+        expect(ok.attributes("disabled")).toBeUndefined();
+
+        form.vm.$emit("validate", false);
+        await Vue.nextTick();
+        expect(ok.attributes("disabled")).toBe("disabled");
     });
 });

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -6,38 +6,38 @@ import EditParameters from "@/components/parameters/EditParameters.vue";
 
 describe("Parameters", () => {
     const paramGroupMetadata = [
-      {
-        id: "pg1",
-        type: "dynamicForm",
-        config: {
-          controlSections: [
-            {
-              label: "cs1.1",
-              control: {
-                value: "old1"
-              }
-            },
-            {
-              label: "cs1.2"
+        {
+            id: "pg1",
+            type: "dynamicForm",
+            config: {
+                controlSections: [
+                    {
+                        label: "cs1.1",
+                        control: {
+                            value: "old1"
+                        }
+                    },
+                    {
+                        label: "cs1.2"
+                    }
+                ]
             }
-          ]
-        }
-      },
-      {
-        id: "pg2",
-        type: "rt"
-      },
-      {
-        id: "pg3",
-        type: "dynamicForm",
-        config: {
-          controlSections: [
-            {
-              label: "cs2.1"
+        },
+        {
+            id: "pg2",
+            type: "rt"
+        },
+        {
+            id: "pg3",
+            type: "dynamicForm",
+            config: {
+                controlSections: [
+                    {
+                        label: "cs2.1"
+                    }
+                ]
             }
-          ]
         }
-      }
     ] as any;
 
     const paramValues = {
@@ -67,7 +67,7 @@ describe("Parameters", () => {
                 {
                     label: "cs1.1",
                     control: {
-                      value: "old1"
+                        value: "old1"
                     },
                     collapsible: true,
                     collapsed: true
@@ -125,21 +125,21 @@ describe("Parameters", () => {
         await Vue.nextTick();
 
         const newParamGroup = {
-          id: "pg1",
-          type: "dynamicForm",
-          config: {
-            controlSections: [
-              {
-                label: "cs1.1",
-                control: {
-                  value: "new1"
-                }
-              },
-              {
-                label: "cs1.2"
-              }
-            ]
-          }
+            id: "pg1",
+            type: "dynamicForm",
+            config: {
+                controlSections: [
+                    {
+                        label: "cs1.1",
+                        control: {
+                            value: "new1"
+                        }
+                    },
+                    {
+                        label: "cs1.2"
+                    }
+                ]
+            }
         };
 
         const newParamValues = { value1: "new1" };
@@ -150,25 +150,27 @@ describe("Parameters", () => {
         expect(editParams.props("open")).toBe(false);
         expect(editParams.props("paramGroup")).toBe(undefined);
 
-        expect(wrapper.emitted("updateMetadata")!!.length).toBe(1);
-        expect(wrapper.emitted("updateMetadata")!![0][0]).toStrictEqual( [
+        const updateMetadata = wrapper.emitted("updateMetadata")!;
+        expect(updateMetadata.length).toBe(1);
+        expect(updateMetadata[0][0]).toStrictEqual([
             newParamGroup,
             paramGroupMetadata[1],
             paramGroupMetadata[2]
         ]);
 
-        expect(wrapper.emitted("updateValues")!!.length).toBe(1);
-        expect(wrapper.emitted("updateValues")!![0][0]).toStrictEqual( {
-          pg1: {
-            value1: "new1",
-            value2: "unchanged"
-          },
-          pg2: {
-            value3: "val3"
-          },
-          pg3: {
-            value4: "val4"
-          }
+        const updateValues = wrapper.emitted("updateValues")!;
+        expect(updateValues.length).toBe(1);
+        expect(updateValues[0][0]).toStrictEqual({
+            pg1: {
+                value1: "new1",
+                value2: "unchanged"
+            },
+            pg2: {
+                value3: "val3"
+            },
+            pg3: {
+                value4: "val4"
+            }
         });
     });
 });

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -1,48 +1,77 @@
 import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
 import Parameters from "@/components/parameters/Parameters.vue";
 import { DynamicForm } from "@reside-ic/vue-dynamic-form";
+import EditParameters from "@/components/parameters/EditParameters.vue";
 
 describe("Parameters", () => {
-    it("renders dynamicForm parameter groups with collapsed control sections", () => {
-        const paramGroupMetadata = [
+    const paramGroupMetadata = [
+      {
+        id: "pg1",
+        type: "dynamicForm",
+        config: {
+          controlSections: [
             {
-                id: "pg1",
-                type: "dynamicForm",
-                config: {
-                    controlSections: [
-                        {
-                            label: "cs1.1"
-                        },
-                        {
-                            label: "cs1.2"
-                        }
-                    ]
-                }
+              label: "cs1.1",
+              control: {
+                value: "old1"
+              }
             },
             {
-                id: "pg2",
-                type: "rt"
-            },
-            {
-                id: "pg3",
-                type: "dynamicForm",
-                config: {
-                    controlSections: [
-                        {
-                            label: "cs2.1"
-                        }
-                    ]
-                }
+              label: "cs1.2"
             }
-        ] as any;
+          ]
+        }
+      },
+      {
+        id: "pg2",
+        type: "rt"
+      },
+      {
+        id: "pg3",
+        type: "dynamicForm",
+        config: {
+          controlSections: [
+            {
+              label: "cs2.1"
+            }
+          ]
+        }
+      }
+    ] as any;
 
-        const wrapper = shallowMount(Parameters, { propsData: { paramGroupMetadata } });
+    const paramValues = {
+        pg1: {
+            value1: "old1",
+            value2: "unchanged"
+        },
+        pg2: {
+            value3: "val3"
+        },
+        pg3: {
+            value4: "val4"
+        }
+    };
+
+    function getWrapper() {
+        return shallowMount(Parameters, { propsData: { paramGroupMetadata, paramValues } });
+    }
+
+    it("renders dynamicForm parameter groups with collapsed control sections", () => {
+        const wrapper = getWrapper();
         const dynForms = wrapper.findAllComponents(DynamicForm);
         expect(dynForms.length).toBe(2);
         expect(dynForms.at(0).props("readonly")).toStrictEqual(true);
         expect(dynForms.at(0).props("formMeta")).toStrictEqual({
             controlSections: [
-                { label: "cs1.1", collapsible: true, collapsed: true },
+                {
+                    label: "cs1.1",
+                    control: {
+                      value: "old1"
+                    },
+                    collapsible: true,
+                    collapsed: true
+                },
                 { label: "cs1.2", collapsible: true, collapsed: true }
             ]
         });
@@ -51,6 +80,95 @@ describe("Parameters", () => {
             controlSections: [
                 { label: "cs2.1", collapsible: true, collapsed: true }
             ]
+        });
+    });
+
+    it("renders Edit buttons", () => {
+        const wrapper = getWrapper();
+        const buttons = wrapper.findAll("button");
+        expect(buttons.length).toBe(2);
+        expect(buttons.at(0).text()).toBe("Edit");
+        expect(buttons.at(1).text()).toBe("Edit");
+    });
+
+    it("renders EditParameters component", () => {
+        const wrapper = getWrapper();
+        const editParams = wrapper.findComponent(EditParameters);
+        expect(editParams.props("open")).toBe(false);
+        expect(editParams.props("paramGroup")).toBe(undefined);
+    });
+
+    it("clicking Edit button opens EditParameters", async () => {
+        const wrapper = getWrapper();
+        wrapper.findAll("button").at(0).trigger("click");
+        await Vue.nextTick();
+        const editParams = wrapper.findComponent(EditParameters);
+        expect(editParams.props("open")).toBe(true);
+        expect(editParams.props("paramGroup")).toBe(paramGroupMetadata[0]);
+    });
+
+    it("cancelling from EditParameters closes modal", async () => {
+        const wrapper = getWrapper();
+        wrapper.findAll("button").at(0).trigger("click");
+        await Vue.nextTick();
+
+        const editParams = wrapper.findComponent(EditParameters);
+        editParams.vm.$emit("cancel");
+        await Vue.nextTick();
+        expect(editParams.props("open")).toBe(false);
+        expect(editParams.props("paramGroup")).toBe(undefined);
+    });
+
+    it("updating from EditParameters closes modal, emits updates", async () => {
+        const wrapper = getWrapper();
+        wrapper.findAll("button").at(0).trigger("click");
+        await Vue.nextTick();
+
+        const newParamGroup = {
+          id: "pg1",
+          type: "dynamicForm",
+          config: {
+            controlSections: [
+              {
+                label: "cs1.1",
+                control: {
+                  value: "new1"
+                }
+              },
+              {
+                label: "cs1.2"
+              }
+            ]
+          }
+        };
+
+        const newParamValues = { value1: "new1" };
+
+        const editParams = wrapper.findComponent(EditParameters);
+        editParams.vm.$emit("update", newParamGroup, newParamValues);
+        await Vue.nextTick();
+        expect(editParams.props("open")).toBe(false);
+        expect(editParams.props("paramGroup")).toBe(undefined);
+
+        expect(wrapper.emitted("updateMetadata")!!.length).toBe(1);
+        expect(wrapper.emitted("updateMetadata")!![0][0]).toStrictEqual( [
+            newParamGroup,
+            paramGroupMetadata[1],
+            paramGroupMetadata[2]
+        ]);
+
+        expect(wrapper.emitted("updateValues")!!.length).toBe(1);
+        expect(wrapper.emitted("updateValues")!![0][0]).toStrictEqual( {
+          pg1: {
+            value1: "new1",
+            value2: "unchanged"
+          },
+          pg2: {
+            value3: "val3"
+          },
+          pg3: {
+            value4: "val4"
+          }
         });
     });
 });

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -41,8 +41,29 @@ describe("actions", () => {
 
         expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({ param1: "value1" });
 
+        expect(commit.mock.calls.length).toBe(3);
+        expect(commit.mock.calls[0][0]).toBe("setFetchingResults");
+        expect(commit.mock.calls[0][1]).toBe(true);
+        expect(commit.mock.calls[1][0]).toBe("setResults");
+        expect(commit.mock.calls[1][1]).toStrictEqual(mockResults);
+        expect(commit.mock.calls[2][0]).toBe("setFetchingResults");
+        expect(commit.mock.calls[2][1]).toBe(false);
+    });
+
+    it("updates parameter values", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const mockParams = {
+            grp1: {
+                name1: "value1"
+            }
+        };
+
+        await (actions.updateParameterValues as any)({ commit, dispatch }, mockParams);
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0]).toBe("setResults");
-        expect(commit.mock.calls[0][1]).toStrictEqual(mockResults);
+        expect(commit.mock.calls[0][0]).toBe("setParameterValues");
+        expect(commit.mock.calls[0][1]).toBe(mockParams);
+        expect(dispatch.mock.calls.length).toBe(1);
+        expect(dispatch.mock.calls[0][0]).toBe("getResults");
     });
 });

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -15,4 +15,30 @@ describe("mutations", () => {
         mutations.setResults(state, mockResults);
         expect(state.results).toBe(mockResults);
     });
+
+    it("sets parameter metadata", () => {
+        const state = mockRootState({ metadata: { charts: [], parameterGroups: []} as any});
+        const newParamMetadata = [
+            { id: "group1" },
+            { id: "group2" }
+        ];
+        mutations.setParameterMetadata(state, newParamMetadata as any);
+        expect(state.metadata).toStrictEqual({
+            charts: [],
+            parameterGroups: newParamMetadata
+        });
+    });
+
+    it("sets parameter values", () => {
+        const state = mockRootState();
+        const mockParamValues = { grp1: { param1: "value1" } };
+        mutations.setParameterValues(state, mockParamValues);
+        expect(state.paramValues).toBe(mockParamValues);
+    });
+
+    it("sets fetchingResults", () => {
+        const state = mockRootState();
+        mutations.setFetchingResults(state, true);
+        expect(state.fetchingResults).toBe(true);
+    });
 });

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -17,7 +17,7 @@ describe("mutations", () => {
     });
 
     it("sets parameter metadata", () => {
-        const state = mockRootState({ metadata: { charts: [], parameterGroups: []} as any});
+        const state = mockRootState({ metadata: { charts: [], parameterGroups: [] } as any });
         const newParamMetadata = [
             { id: "group1" },
             { id: "group2" }


### PR DESCRIPTION
- This branch enables editing of dynamic form parameters via modal dialogs. When the user OKs from dialog, results are re-fetched and the view updated. An 'Updating analysis..' indicator is displayed while results are being fetched, both on initial fetch and after parameter changes. Try updating the healthcare capacity values, and see the horizontal lines update on the Healthcare demand chart. 
- The 'Edit' buttons appear unattractively bolted below each collapsed readonly parameter form, rather than being rolled into the collapsed section. I'm going to address this in a separate branch by implementing the collapsible panels in the app rather than using the collapse functionality in the dynamic form (we'll need this for the phases parameters anyway). 
- I'm following the pattern already implicitly started where the Home component interacts with Vuex store while its child components just accept props and emit events. I feel like this makes the components easier to test, and makes the Vuex interactions easier to locate, but it's more long-winded (Parameters component could directly update the store rather than going via Home.)
- Not yet implemented is extracting the default parameter values from parameter metadata - initial values are still hard-coded until a future branch. 
- I've used a couple of handy components copied direct from HINT - LoadingSpinner and Modal. 
- I'm not entirely sure why the barchart seems to stay behind while the other charts refresh - possibly because that's the only chart which has not changed. That suggests there might be some performance issues in the chart rendering. 