### PR TITLE
mrc-2408 Collapsible component for read-only parameters

### DIFF
--- a/src/app/src/main/resources/metadata/parameterGroups/healthcare.jsonata
+++ b/src/app/src/main/resources/metadata/parameterGroups/healthcare.jsonata
@@ -1,7 +1,6 @@
 {
     "controlSections": [
         {
-            "label": "Healthcare capacity",
             "controlGroups": [
                 {
                     "label": "Total general beds",

--- a/src/app/src/main/resources/metadata/parameterGroups/parameterGroups.json
+++ b/src/app/src/main/resources/metadata/parameterGroups/parameterGroups.json
@@ -1,5 +1,5 @@
 [
-  {"id": "healthcare", "type": "dynamicForm"},
-  {"id":  "rt", "type":  "rt"},
-  {"id":  "vaccination", "type": "dynamicForm"}
+  {"id": "healthcare", "label": "Healthcare capacity", "type": "dynamicForm"},
+  {"id":  "rt", "label": "Social restrictions", "type":  "rt"},
+  {"id":  "vaccination", "label": "Vaccination", "type": "dynamicForm"}
 ]

--- a/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
+++ b/src/app/src/main/resources/metadata/parameterGroups/vaccination.jsonata
@@ -1,7 +1,6 @@
 {
     "controlSections": [
         {
-            "label": "Vaccination",
             "controlGroups": [
                 {
                     "label": "Vaccine Efficacy against infection and mild cases (%)",

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -4844,6 +4844,12 @@
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
       "dev": true
     },
+    "babel-helper-vue-jsx-merge-props": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz",
+      "integrity": "sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==",
+      "dev": true
+    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -21238,6 +21244,15 @@
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
+      }
+    },
+    "vue-feather-icons": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vue-feather-icons/-/vue-feather-icons-5.1.0.tgz",
+      "integrity": "sha512-ZyM2yFGmL9DYLZYHm63KV1zCQOj8czC2LzDSkxoIp9o6zMAOY4yv1FkxbX+XNUwcH3RRrAuvf25Ij7CnUUsQVA==",
+      "dev": true,
+      "requires": {
+        "babel-helper-vue-jsx-merge-props": "^2.0.2"
       }
     },
     "vue-functional-data-merge": {

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -4847,8 +4847,7 @@
     "babel-helper-vue-jsx-merge-props": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz",
-      "integrity": "sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==",
-      "dev": true
+      "integrity": "sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg=="
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -21250,7 +21249,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/vue-feather-icons/-/vue-feather-icons-5.1.0.tgz",
       "integrity": "sha512-ZyM2yFGmL9DYLZYHm63KV1zCQOj8czC2LzDSkxoIp9o6zMAOY4yv1FkxbX+XNUwcH3RRrAuvf25Ij7CnUUsQVA==",
-      "dev": true,
       "requires": {
         "babel-helper-vue-jsx-merge-props": "^2.0.2"
       }

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -19,6 +19,7 @@
     "jsonata": "^1.8.4",
     "plotly.js": "^1.58.4",
     "vue": "^2.6.12",
+    "vue-feather-icons": "^5.1.0",
     "vue-router": "^3.1.6",
     "vuex": "^3.6.2"
   },
@@ -45,7 +46,6 @@
     "node-sass": "^4.12.0",
     "sass-loader": "^8.0.2",
     "typescript": "~4.1.5",
-    "vue-feather-icons": "^5.1.0",
     "vue-jest": "^3.0.7",
     "vue-loader": "^15.9.7",
     "vue-template-compiler": "^2.6.12"

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -45,6 +45,7 @@
     "node-sass": "^4.12.0",
     "sass-loader": "^8.0.2",
     "typescript": "~4.1.5",
+    "vue-feather-icons": "^5.1.0",
     "vue-jest": "^3.0.7",
     "vue-loader": "^15.9.7",
     "vue-template-compiler": "^2.6.12"

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -1,35 +1,39 @@
 $body-bg: #eee;
 $theme-blue: #003e74;
 
-.dynamic-form {
-  h3 {
-    font-size: 1.3rem;
+.parameters {
+  .collapsible {
+    h3 {
+      font-size: 1.3rem;
 
-    svg {  //collapse chevrons
-      float: right;
+      svg { //collapse chevrons
+        float: right;
+      }
+    }
+
+    .collapse {
+      background-color: #fafafa;
+      padding-left: 1rem;
     }
   }
 
-  .row {
-    label {
-      max-width: 60%;
-      flex: 0 0 60%;
+  .dynamic-form {
+    .row {
+      label {
+        max-width: 60%;
+        flex: 0 0 60%;
+      }
+
+      & > div {
+        max-width: 40%;
+        flex: 0 0 40%;
+      }
+
+      .dynamic-form-readonly-value {
+        padding-top: 7px;
+      }
+
     }
-
-    & > div {
-      max-width: 40%;
-      flex: 0 0 40%;
-    }
-
-    .dynamic-form-readonly-value {
-      padding-top: 7px;
-    }
-
-  }
-
-  .collapse {
-    background-color: #fafafa;
-    padding-left: 1rem;
   }
 }
 

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -9,35 +9,45 @@ $theme-blue: #003e74;
         float: right;
       }
     }
+  }
 
-    .collapse {
-      background-color: #fafafa;
-      padding-left: 1rem;
+  .parameter-panel {
+    background-color: #fafafa;
+    padding-left: 1rem;
+
+    .dynamic-form {
+      .row {
+        label {
+          max-width: 60%;
+          flex: 0 0 60%;
+        }
+
+        & > div {
+          max-width: 40%;
+          flex: 0 0 40%;
+        }
+
+        .dynamic-form-readonly-value {
+          padding-top: 7px;
+        }
+
+      }
     }
   }
 
-  .dynamic-form {
-    .row {
-      label {
-        max-width: 60%;
-        flex: 0 0 60%;
-      }
-
-      & > div {
-        max-width: 40%;
-        flex: 0 0 40%;
-      }
-
-      .dynamic-form-readonly-value {
-        padding-top: 7px;
-      }
-
+  .edit-parameters {
+    h3 {
+      margin-bottom: 1.5rem;
     }
   }
 }
 
 .btn-action {
   @include button-variant($theme-blue, darken($theme-blue, 10%))
+}
+
+.cursor-pointer {
+  cursor: pointer;
 }
 
 #fetching-results {

--- a/src/app/static/src/components/Collapsible.vue
+++ b/src/app/static/src/components/Collapsible.vue
@@ -1,0 +1,62 @@
+<template>
+  <div>
+    <h3 @click="toggleOpen" :class="cursor-pointer">
+      {{heading}}
+      <component style="vertical-align: initial"
+                 :is="chevronComponent"></component>
+    </h3>
+    <b-collapse v-model="open">
+      <slot></slot>
+    </b-collapse>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { ChevronDownIcon, ChevronUpIcon } from "vue-feather-icons";
+import { BCollapse } from "bootstrap-vue";
+
+interface Methods {
+    toggleOpen: () => void
+}
+
+interface Props {
+    initialOpen: boolean,
+    heading: string
+}
+
+interface Data {
+    open: boolean
+}
+
+export default Vue.extend<Data, Methods, {}, Props>({
+    name: "DynamicFormControlSection",
+    data() {
+        return {
+            open: this.initialOpen
+        };
+    },
+    props: {
+        initialOpen: Boolean,
+        heading: String
+    },
+    computed: {
+        chevronComponent() {
+            if (this.open) {
+                return "chevron-up-icon"
+            }
+            return "chevron-down-icon"
+        }
+    },
+    methods: {
+        toggleOpen() {
+            this.open = !this.open;
+        }
+    },
+    components: {
+        ChevronDownIcon,
+        ChevronUpIcon,
+        BCollapse
+    }
+});
+</script>

--- a/src/app/static/src/components/Collapsible.vue
+++ b/src/app/static/src/components/Collapsible.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h3 @click="toggleOpen" :class="cursor-pointer">
+    <h3 @click="toggleOpen" class="cursor-pointer">
       {{heading}}
       <component style="vertical-align: initial"
                  :is="chevronComponent"></component>

--- a/src/app/static/src/components/Collapsible.vue
+++ b/src/app/static/src/components/Collapsible.vue
@@ -29,7 +29,7 @@ interface Data {
     open: boolean
 }
 
-export default Vue.extend<Data, Methods, {}, Props>({
+export default Vue.extend<Data, Methods, Record<string, never>, Props>({
     name: "DynamicFormControlSection",
     data() {
         return {

--- a/src/app/static/src/components/Collapsible.vue
+++ b/src/app/static/src/components/Collapsible.vue
@@ -43,9 +43,9 @@ export default Vue.extend<Data, Methods, {}, Props>({
     computed: {
         chevronComponent() {
             if (this.open) {
-                return "chevron-up-icon"
+                return "chevron-up-icon";
             }
-            return "chevron-down-icon"
+            return "chevron-down-icon";
         }
     },
     methods: {

--- a/src/app/static/src/components/Collapsible.vue
+++ b/src/app/static/src/components/Collapsible.vue
@@ -29,7 +29,7 @@ interface Data {
     open: boolean
 }
 
-export default Vue.extend<Data, Methods, Record<string, never>, Props>({
+export default Vue.extend<Data, Methods, unknown, Props>({
     name: "DynamicFormControlSection",
     data() {
         return {

--- a/src/app/static/src/components/parameters/EditParameters.vue
+++ b/src/app/static/src/components/parameters/EditParameters.vue
@@ -1,6 +1,7 @@
 <template>
 <div>
   <modal :open="open">
+    <h3>Edit {{paramGroup.label}} parameters</h3>
     <dynamic-form
       v-if="open"
       ref="form"

--- a/src/app/static/src/components/parameters/EditParameters.vue
+++ b/src/app/static/src/components/parameters/EditParameters.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
   <modal :open="open">
-    <h3>Edit {{paramGroup.label}} parameters</h3>
+    <h3>Edit {{paramGroup && paramGroup.label}} parameters</h3>
     <dynamic-form
       v-if="open"
       ref="form"

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,12 +1,14 @@
 <template>
   <div>
-    <div v-for="paramGroup in readOnlyParamGroups" :key="paramGroup.id">
+    <div v-for="paramGroup in paramGroupMetadata" :key="paramGroup.id">
       <div v-if="paramGroup.type == 'dynamicForm'" class="clearfix">
-        <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
-                    v-model="paramGroup.config"
-                    :readonly="true"></dynamic-form>
-        <button class="btn btn-action float-right mb-3"
-                @click="editParameters(paramGroup.id)">Edit</button>
+        <collapsible class="collapsible" :initial-open="false" :heading="paramGroup.label">
+          <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
+                      v-model="paramGroup.config"
+                      :readonly="true"></dynamic-form>
+          <button class="btn btn-action float-right mb-3"
+                  @click="editParameters(paramGroup.id)">Edit</button>
+        </collapsible>
       </div>
     </div>
     <edit-parameters
@@ -28,6 +30,7 @@ import {
 } from "@reside-ic/vue-dynamic-form";
 import { Data, ParameterGroupMetadata } from "@/types";
 import EditParameters from "./EditParameters.vue";
+import Collapsible from "@/components/Collapsible.vue";
 
 interface Props {
     paramGroupMetadata: Array<ParameterGroupMetadata>
@@ -38,7 +41,8 @@ export default defineComponent({
     name: "Parameters",
     components: {
         DynamicForm,
-        EditParameters
+        EditParameters,
+        Collapsible
     },
     props: {
         paramGroupMetadata: Array,
@@ -46,7 +50,7 @@ export default defineComponent({
     },
     setup(props: Props, context) {
         // Display readonly parameters as collapsible panels
-        const collapseSections = (config: DynamicFormMeta) => {
+        /*const collapseSections = (config: DynamicFormMeta) => {
             return config.controlSections.map((section: DynamicControlSection) => {
                 return {
                     ...section,
@@ -69,7 +73,7 @@ export default defineComponent({
                 }
                 return metadata;
             });
-        });
+        });*/
 
         const modalOpen = ref(false);
         const editParamGroupId = ref("");
@@ -110,7 +114,7 @@ export default defineComponent({
         }
 
         return {
-            readOnlyParamGroups,
+            //readOnlyParamGroups,
             modalOpen,
             editParamGroupId,
             editParamGroup,

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -16,7 +16,6 @@
     </div>
     <edit-parameters
       class="edit-parameters"
-      v-if="editParamGroup"
       :open="modalOpen"
       :paramGroup="editParamGroup"
       @cancel="closeModal"

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -27,14 +27,12 @@
 <script lang="ts">
 import { computed, defineComponent, ref } from "@vue/composition-api";
 import {
-    DynamicControlSection,
     DynamicForm,
-    DynamicFormData,
-    DynamicFormMeta
+    DynamicFormData
 } from "@reside-ic/vue-dynamic-form";
 import { Data, ParameterGroupMetadata } from "@/types";
-import EditParameters from "./EditParameters.vue";
 import Collapsible from "@/components/Collapsible.vue";
+import EditParameters from "./EditParameters.vue";
 
 interface Props {
     paramGroupMetadata: Array<ParameterGroupMetadata>

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,17 +1,22 @@
 <template>
   <div>
     <div v-for="paramGroup in paramGroupMetadata" :key="paramGroup.id">
-      <div v-if="paramGroup.type == 'dynamicForm'" class="clearfix">
-        <collapsible class="collapsible" :initial-open="false" :heading="paramGroup.label">
-          <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
-                      v-model="paramGroup.config"
-                      :readonly="true"></dynamic-form>
-          <button class="btn btn-action float-right mb-3"
-                  @click="editParameters(paramGroup.id)">Edit</button>
+      <div v-if="paramGroup.type == 'dynamicForm'">
+        <collapsible class="collapsible mt-2" :initial-open="false" :heading="paramGroup.label">
+          <div class="parameter-panel">
+            <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
+                        v-model="paramGroup.config"
+                        :readonly="true"></dynamic-form>
+            <button class="btn btn-action float-right mb-3 mr-3"
+                    @click="editParameters(paramGroup.id)">Edit</button>
+            <span class="clearfix"></span>
+          </div>
         </collapsible>
       </div>
     </div>
     <edit-parameters
+      class="edit-parameters"
+      v-if="editParamGroup"
       :open="modalOpen"
       :paramGroup="editParamGroup"
       @cancel="closeModal"
@@ -49,32 +54,6 @@ export default defineComponent({
         paramValues: Object
     },
     setup(props: Props, context) {
-        // Display readonly parameters as collapsible panels
-        /*const collapseSections = (config: DynamicFormMeta) => {
-            return config.controlSections.map((section: DynamicControlSection) => {
-                return {
-                    ...section,
-                    collapsible: true,
-                    collapsed: true
-                };
-            });
-        };
-
-        const readOnlyParamGroups = computed(() => {
-            return props.paramGroupMetadata.map((metadata: ParameterGroupMetadata) => {
-                if (metadata.type === "dynamicForm") {
-                    const controlSections = collapseSections(metadata.config as DynamicFormMeta);
-                    return {
-                        ...metadata,
-                        config: {
-                            controlSections
-                        }
-                    };
-                }
-                return metadata;
-            });
-        });*/
-
         const modalOpen = ref(false);
         const editParamGroupId = ref("");
 
@@ -114,7 +93,6 @@ export default defineComponent({
         }
 
         return {
-            //readOnlyParamGroups,
             modalOpen,
             editParamGroupId,
             editParamGroup,

--- a/src/app/static/src/shims-vue.d.ts
+++ b/src/app/static/src/shims-vue.d.ts
@@ -4,3 +4,5 @@ declare module '*.vue' {
   const component: DefineComponent<{}, {}, any>
   export default component
 }
+
+declare module "vue-feather-icons";

--- a/src/app/static/src/types.ts
+++ b/src/app/static/src/types.ts
@@ -38,6 +38,7 @@ export interface ParameterGroupJsonataMetadata {
 
 export interface ParameterGroupMetadata {
     id: string,
+    label: string,
     type: "dynamicForm" | "rt",
     config: DynamicFormMeta | Rt[]
 }

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="home row">
-    <Parameters class="parameters col-md-4" v-if="metadata"
-                :paramGroupMetadata="metadata.parameterGroups"
-                :paramValues="paramValues"
-                @updateMetadata="setParameterMetadata"
-                @updateValues="updateParameterValues"></Parameters>
+    <div class="col-md-4">
+      <Parameters class="parameters" v-if="metadata"
+                  :paramGroupMetadata="metadata.parameterGroups"
+                  :paramValues="paramValues"
+                  @updateMetadata="setParameterMetadata"
+                  @updateValues="updateParameterValues"></Parameters>
+    </div>
     <div class="col-md-8">
       <Charts v-if="metadata && !fetchingResults"
               :chart-metadata="metadata.charts"

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="home row">
-    <Parameters class="col-md-4" v-if="metadata"
+    <Parameters class="parameters col-md-4" v-if="metadata"
                 :paramGroupMetadata="metadata.parameterGroups"
                 :paramValues="paramValues"
                 @updateMetadata="setParameterMetadata"

--- a/src/app/static/tests/unit/components/collapsible.test.ts
+++ b/src/app/static/tests/unit/components/collapsible.test.ts
@@ -1,11 +1,10 @@
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import Vue from "vue";
 import Collapsible from "@/components/Collapsible.vue";
 import { ChevronDownIcon, ChevronUpIcon } from "vue-feather-icons";
 import { BCollapse } from "bootstrap-vue";
 
 describe("Collapsible", () => {
-
     function getWrapper(propsData = { initialOpen: true, heading: "Test Heading" }) {
         return shallowMount(Collapsible, {
             propsData,

--- a/src/app/static/tests/unit/components/collapsible.test.ts
+++ b/src/app/static/tests/unit/components/collapsible.test.ts
@@ -1,0 +1,55 @@
+import {shallowMount} from "@vue/test-utils";
+import Vue from "vue";
+import Collapsible from "@/components/Collapsible.vue";
+import { ChevronDownIcon, ChevronUpIcon } from "vue-feather-icons";
+import { BCollapse } from "bootstrap-vue";
+
+describe("Collapsible", () => {
+
+    function getWrapper(propsData = { initialOpen: true, heading: "Test Heading" }) {
+        return shallowMount(Collapsible, {
+            propsData,
+            slots: { default: "<div id='content'>test content</div>" }
+        });
+    }
+
+    it("renders as expected when open", () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find("h3").text()).toBe("Test Heading");
+        expect(wrapper.findComponent(ChevronUpIcon).exists()).toBe(true);
+        expect(wrapper.findComponent(ChevronDownIcon).exists()).toBe(false);
+
+        expect(wrapper.findComponent(BCollapse).props("visible")).toBe(true);
+        expect(wrapper.findComponent(BCollapse).find("#content").text()).toBe("test content");
+    });
+
+    it("renders as expected when closed", () => {
+        const wrapper = getWrapper({ initialOpen: false, heading: "Test Heading" });
+
+        expect(wrapper.find("h3").text()).toBe("Test Heading");
+        expect(wrapper.findComponent(ChevronUpIcon).exists()).toBe(false);
+        expect(wrapper.findComponent(ChevronDownIcon).exists()).toBe(true);
+
+        expect(wrapper.findComponent(BCollapse).props("visible")).toBe(false);
+        expect(wrapper.findComponent(BCollapse).find("#content").text()).toBe("test content");
+    });
+
+    it("clicking heading toggles open", async () => {
+        const wrapper = getWrapper();
+        const heading = wrapper.find("h3");
+        heading.trigger("click");
+
+        await Vue.nextTick();
+        expect(wrapper.findComponent(ChevronUpIcon).exists()).toBe(false);
+        expect(wrapper.findComponent(ChevronDownIcon).exists()).toBe(true);
+        expect(wrapper.findComponent(BCollapse).props("visible")).toBe(false);
+
+        heading.trigger("click");
+
+        await Vue.nextTick();
+        expect(wrapper.findComponent(ChevronUpIcon).exists()).toBe(true);
+        expect(wrapper.findComponent(ChevronDownIcon).exists()).toBe(false);
+        expect(wrapper.findComponent(BCollapse).props("visible")).toBe(true);
+    });
+});

--- a/src/app/static/tests/unit/components/parameters/editParameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editParameters.test.ts
@@ -7,11 +7,11 @@ import { DynamicForm } from "@reside-ic/vue-dynamic-form";
 describe("EditParameters", () => {
     const paramGroup = {
         id: "healthcare",
+        label: "Healthcare capacity",
         type: "dynamicForm",
         config: {
             controlSections: [
                 {
-                    label: "Healthcare capacity",
                     controlGroups: [
                         {
                             label: "Total general beds",
@@ -31,11 +31,11 @@ describe("EditParameters", () => {
 
     const modifiedParamGroup = {
         id: "healthcare",
+        label: "Healthcare capacity",
         type: "dynamicForm",
         config: {
             controlSections: [
                 {
-                    label: "Healthcare capacity",
                     controlGroups: [
                         {
                             label: "Total general beds",
@@ -60,6 +60,7 @@ describe("EditParameters", () => {
 
     it("renders as expected", () => {
         let wrapper = getWrapper();
+        expect(wrapper.find("h3").text()).toBe("Edit Healthcare capacity parameters");
         expect(wrapper.findComponent(DynamicForm).props("formMeta")).toBe(paramGroup.config);
         expect(wrapper.findComponent(Modal).props("open")).toBe(true);
         expect(wrapper.find(".btn-action").text()).toBe("OK");

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -3,11 +3,13 @@ import Vue from "vue";
 import Parameters from "@/components/parameters/Parameters.vue";
 import { DynamicForm } from "@reside-ic/vue-dynamic-form";
 import EditParameters from "@/components/parameters/EditParameters.vue";
+import Collapsible from "@/components/Collapsible.vue";
 
 describe("Parameters", () => {
     const paramGroupMetadata = [
         {
             id: "pg1",
+            label:"Group 1",
             type: "dynamicForm",
             config: {
                 controlSections: [
@@ -25,10 +27,12 @@ describe("Parameters", () => {
         },
         {
             id: "pg2",
+            label: "Group 2",
             type: "rt"
         },
         {
             id: "pg3",
+            label: "Group 3",
             type: "dynamicForm",
             config: {
                 controlSections: [
@@ -57,30 +61,22 @@ describe("Parameters", () => {
         return shallowMount(Parameters, { propsData: { paramGroupMetadata, paramValues } });
     }
 
-    it("renders dynamicForm parameter groups with collapsed control sections", () => {
+    it("renders collapsible dynamicForm parameter groups", () => {
         const wrapper = getWrapper();
-        const dynForms = wrapper.findAllComponents(DynamicForm);
-        expect(dynForms.length).toBe(2);
-        expect(dynForms.at(0).props("readonly")).toStrictEqual(true);
-        expect(dynForms.at(0).props("formMeta")).toStrictEqual({
-            controlSections: [
-                {
-                    label: "cs1.1",
-                    control: {
-                        value: "old1"
-                    },
-                    collapsible: true,
-                    collapsed: true
-                },
-                { label: "cs1.2", collapsible: true, collapsed: true }
-            ]
-        });
-        expect(dynForms.at(1).props("readonly")).toStrictEqual(true);
-        expect(dynForms.at(1).props("formMeta")).toStrictEqual({
-            controlSections: [
-                { label: "cs2.1", collapsible: true, collapsed: true }
-            ]
-        });
+        const collapsibles = wrapper.findAllComponents(Collapsible);
+        expect(collapsibles.length).toBe(2);
+
+        expect(collapsibles.at(0).props("initialOpen")).toBe(false);
+        expect(collapsibles.at(0).props("heading")).toBe("Group 1");
+        const form1 = collapsibles.at(0).findComponent(DynamicForm);
+        expect(form1.props("readonly")).toStrictEqual(true);
+        expect(form1.props("formMeta")).toStrictEqual(paramGroupMetadata[0].config);
+
+        expect(collapsibles.at(1).props("initialOpen")).toBe(false);
+        expect(collapsibles.at(1).props("heading")).toBe("Group 3");
+        const form2 = collapsibles.at(1).findComponent(DynamicForm);
+        expect(form2.props("readonly")).toStrictEqual(true);
+        expect(form2.props("formMeta")).toStrictEqual(paramGroupMetadata[2].config);
     });
 
     it("renders Edit buttons", () => {

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -9,7 +9,7 @@ describe("Parameters", () => {
     const paramGroupMetadata = [
         {
             id: "pg1",
-            label:"Group 1",
+            label: "Group 1",
             type: "dynamicForm",
             config: {
                 controlSections: [


### PR DESCRIPTION
Adds a `Collapsible` panel component to allow parameter forms along with their edit buttons to be collapsed together. We'll also use this to make Charts collapsible. Removes code making parameter groups collapsible using vue-dynamic-form's collapse functionality by doctoring the form metadata.