### PR TITLE
mrc-2409 API error handling

### DIFF
--- a/src/app/static/src/components/Errors.vue
+++ b/src/app/static/src/components/Errors.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <div v-for="error in errors">
+      {{error.detail}}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent} from "@vue/composition-api";
+
+export default defineComponent({
+    name: "Errors",
+    props: ["errors"]
+});
+</script>

--- a/src/app/static/src/components/Errors.vue
+++ b/src/app/static/src/components/Errors.vue
@@ -1,12 +1,16 @@
 <template>
   <div>
-    <b-alert v-for="(error, idx) in errors"
-         v-bind:key="idx"
+    <b-alert v-if="errors.length > 0"
          variant="danger"
          show
-         dismissible>
-      <strong>An error occurred:</strong>
-      {{ error.detail || error.error }}
+         dismissible
+         @dismissed="$emit('dismissed')">
+      <strong>{{errors.length > 1 ? "Errors occurred:" : "An error occurred:"}}</strong>
+      <ul>
+        <li v-for="(error, idx) in errors" :key="idx">
+          {{ error.detail || error.error }}
+        </li>
+      </ul>
     </b-alert>
   </div>
 </template>

--- a/src/app/static/src/components/Errors.vue
+++ b/src/app/static/src/components/Errors.vue
@@ -1,16 +1,25 @@
 <template>
   <div>
-    <div v-for="error in errors">
-      {{error.detail}}
-    </div>
+    <b-alert v-for="(error, idx) in errors"
+         v-bind:key="idx"
+         variant="danger"
+         show
+         dismissible>
+      <strong>An error occurred:</strong>
+      {{ error.detail || error.error }}
+    </b-alert>
   </div>
 </template>
 
 <script lang="ts">
-import {defineComponent} from "@vue/composition-api";
+import { defineComponent } from "@vue/composition-api";
+import { BAlert } from "bootstrap-vue";
 
 export default defineComponent({
     name: "Errors",
-    props: ["errors"]
+    props: ["errors"],
+    components: {
+        BAlert
+    }
 });
 </script>

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -4,7 +4,7 @@ import { RootState } from "@/store/state";
 import { ErrorInfo, ParameterGroupJsonataMetadata } from "@/types";
 import jsonata from "jsonata";
 
-function commitErrors(e: AxiosError, commit: Commit) {
+export function commitErrors(e: AxiosError, commit: Commit): void {
     let errors: Array<ErrorInfo>;
     if (e.response && e.response.data) {
         errors = e.response.data.errors;

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -10,7 +10,7 @@ export const actions: ActionTree<RootState, RootState> = {
           .then(({ data }) => {
               commit("setApiInfo", data.data);
           }).catch((e: AxiosError) => {
-            commitErrors(e, commit);
+              commitErrors(e, commit);
           });
     },
     async getMetadata({ commit }) {
@@ -29,6 +29,7 @@ export const actions: ActionTree<RootState, RootState> = {
     },
     async getResults({ commit, state }) {
         commit("setFetchingResults", true);
+        commit("setErrors", []);
         await axios.post("/results", state.paramValues)
           .then(({ data }) => {
               commit("setResults", data.data);
@@ -51,7 +52,7 @@ function commitErrors(e: AxiosError, commit: Commit) {
     } else if (e.message) {
         errors = [{ error: e.message }] ;
     } else {
-        errors = [{ error: "Unable to contact server " }];
+        errors = [{ error: "Unable to contact server" }];
     }
     commit("setErrors", errors);
 }

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -23,6 +23,7 @@ export const actions: ActionTree<RootState, RootState> = {
               commit("setMetadata", data.data);
           }).catch(({ response }) => {
               commit("setErrors", response.data && response.data.errors);
+              //TODO: Could be message if no response from server - handle in common method
           });
     },
     async getResults({ commit, state }) {

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -6,9 +6,9 @@ import jsonata from "jsonata";
 
 export function commitErrors(e: AxiosError, commit: Commit): void {
     let errors: Array<ErrorInfo>;
-    if (e.response?.data.errors) {
+    if (e.response?.data?.errors) {
         errors = e.response.data.errors;
-    } else if (e.response && e.response.data && e.response.data.error) {
+    } else if (e.response?.data?.error) {
         errors = [{ error: e.response.data.error }];
     } else if (e.message) {
         errors = [{ error: e.message }];

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -6,7 +6,7 @@ import jsonata from "jsonata";
 
 export function commitErrors(e: AxiosError, commit: Commit): void {
     let errors: Array<ErrorInfo>;
-    if (e.response && e.response.data && e.response.data.errors) {
+    if (e.response?.data.errors) {
         errors = e.response.data.errors;
     } else if (e.response && e.response.data && e.response.data.error) {
         errors = [{ error: e.response.data.error }];

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, {AxiosError} from "axios";
 import { ActionTree } from "vuex";
 import { RootState } from "@/store/state";
 import { ParameterGroupJsonataMetadata } from "@/types";
@@ -6,24 +6,34 @@ import jsonata from "jsonata";
 
 export const actions: ActionTree<RootState, RootState> = {
     async getApiInfo({ commit }) {
-        const { data } = await axios.get("/api-info");
-        commit("setApiInfo", data.data);
+        await axios.get("/api-info")
+          .then(({ data }) => {
+              commit("setApiInfo", data.data);
+          });
     },
     async getMetadata({ commit }) {
-        const { data } = await axios.get("/metadata");
+        await axios.get("/metadata")
+          .then(({ data })=> {
+              // populate any dynamic values in the config by evaluating the jsonata
+              data.data.parameterGroups = data.data.parameterGroups
+                .map((g: ParameterGroupJsonataMetadata) => {
+                  return { ...g, config: jsonata(g.config).evaluate({}) };
+                });
 
-        // populate any dynamic values in the config by evaluating the jsonata
-        data.data.parameterGroups = data.data.parameterGroups
-            .map((g: ParameterGroupJsonataMetadata) => {
-                return { ...g, config: jsonata(g.config).evaluate({}) };
-            });
-
-        commit("setMetadata", data.data);
+              commit("setMetadata", data.data);
+          }).catch(({ response }) => {
+              commit("setErrors", response.data && response.data.errors);
+          });
     },
     async getResults({ commit, state }) {
         commit("setFetchingResults", true);
-        const { data } = await axios.post("/results", state.paramValues);
-        commit("setResults", data.data);
+        await axios.post("/results", state.paramValues)
+          .then(({ data }) => {
+              commit("setResults", data.data);
+          }).catch(({ response }) => {
+              commit("setErrors", response.data && response.data.errors);
+          });
+
         commit("setFetchingResults", false);
     },
     async updateParameterValues({ commit, dispatch }, newValues) {

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -6,8 +6,10 @@ import jsonata from "jsonata";
 
 export function commitErrors(e: AxiosError, commit: Commit): void {
     let errors: Array<ErrorInfo>;
-    if (e.response && e.response.data) {
+    if (e.response && e.response.data && e.response.data.errors) {
         errors = e.response.data.errors;
+    } else if (e.response && e.response.data && e.response.data.error) {
+        errors = [{ error: e.response.data.error }];
     } else if (e.message) {
         errors = [{ error: e.message }];
     } else {

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -1,41 +1,54 @@
-import axios, {AxiosError} from "axios";
-import {ActionTree, Commit} from "vuex";
+import axios, { AxiosError } from "axios";
+import { ActionTree, Commit } from "vuex";
 import { RootState } from "@/store/state";
-import {ErrorInfo, ParameterGroupJsonataMetadata} from "@/types";
+import { ErrorInfo, ParameterGroupJsonataMetadata } from "@/types";
 import jsonata from "jsonata";
+
+function commitErrors(e: AxiosError, commit: Commit) {
+    let errors: Array<ErrorInfo>;
+    if (e.response && e.response.data) {
+        errors = e.response.data.errors;
+    } else if (e.message) {
+        errors = [{ error: e.message }];
+    } else {
+        errors = [{ error: "Unable to contact server" }];
+    }
+    commit("setErrors", errors);
+}
 
 export const actions: ActionTree<RootState, RootState> = {
     async getApiInfo({ commit }) {
         await axios.get("/api-info")
-          .then(({ data }) => {
-              commit("setApiInfo", data.data);
-          }).catch((e: AxiosError) => {
-              commitErrors(e, commit);
-          });
+            .then(({ data }) => {
+                commit("setApiInfo", data.data);
+            }).catch((e: AxiosError) => {
+                commitErrors(e, commit);
+            });
     },
     async getMetadata({ commit }) {
         await axios.get("/metadata")
-          .then(({ data })=> {
-              // populate any dynamic values in the config by evaluating the jsonata
-              data.data.parameterGroups = data.data.parameterGroups
-                .map((g: ParameterGroupJsonataMetadata) => {
-                  return { ...g, config: jsonata(g.config).evaluate({}) };
-                });
+            .then((response) => {
+                // populate any dynamic values in the config by evaluating the jsonata
+                const { data } = response;
+                data.data.parameterGroups = data.data.parameterGroups
+                    .map((g: ParameterGroupJsonataMetadata) => {
+                        return { ...g, config: jsonata(g.config).evaluate({}) };
+                    });
 
-              commit("setMetadata", data.data);
-          }).catch((e: AxiosError) => {
-              commitErrors(e, commit);
-          });
+                commit("setMetadata", data.data);
+            }).catch((e: AxiosError) => {
+                commitErrors(e, commit);
+            });
     },
     async getResults({ commit, state }) {
         commit("setFetchingResults", true);
         commit("setErrors", []);
         await axios.post("/results", state.paramValues)
-          .then(({ data }) => {
-              commit("setResults", data.data);
-          }).catch((e: AxiosError) => {
-              commitErrors(e, commit);
-          });
+            .then(({ data }) => {
+                commit("setResults", data.data);
+            }).catch((e: AxiosError) => {
+                commitErrors(e, commit);
+            });
 
         commit("setFetchingResults", false);
     },
@@ -44,15 +57,3 @@ export const actions: ActionTree<RootState, RootState> = {
         dispatch("getResults");
     }
 };
-
-function commitErrors(e: AxiosError, commit: Commit) {
-    let errors: Array<ErrorInfo>;
-    if (e.response && e.response.data) {
-        errors = e.response.data.errors;
-    } else if (e.message) {
-        errors = [{ error: e.message }] ;
-    } else {
-        errors = [{ error: "Unable to contact server" }];
-    }
-    commit("setErrors", errors);
-}

--- a/src/app/static/src/store/index.ts
+++ b/src/app/static/src/store/index.ts
@@ -24,6 +24,7 @@ export default new Vuex.Store<RootState>({
         apiInfo: null,
         metadata: null,
         results: null,
+        errors: [],
         // This auxiliary data required by charts will eventually come out of dynamic parameters
         paramValues: {
             region: "GBR",

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -1,9 +1,9 @@
 import { RootState } from "@/store/state";
 import {
-    ApiInfo,
-    Metadata,
-    Data,
-    ParameterGroupMetadata
+  ApiInfo,
+  Metadata,
+  Data,
+  ParameterGroupMetadata, ErrorInfo
 } from "@/types";
 
 export const mutations = {
@@ -24,5 +24,11 @@ export const mutations = {
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;
+        if (fetchingResults) {
+            state.errors = []; //reset errors too
+        }
+    },
+    setErrors(state: RootState, errors: Array<ErrorInfo>): void {
+        state.errors = errors;
     }
 };

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -24,9 +24,6 @@ export const mutations = {
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;
-        if (fetchingResults) {
-            state.errors = []; //reset errors too
-        }
     },
     setErrors(state: RootState, errors: Array<ErrorInfo>): void {
         state.errors = errors;

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -1,9 +1,10 @@
 import { RootState } from "@/store/state";
 import {
-  ApiInfo,
-  Metadata,
-  Data,
-  ParameterGroupMetadata, ErrorInfo
+    ApiInfo,
+    Metadata,
+    Data,
+    ParameterGroupMetadata,
+    ErrorInfo
 } from "@/types";
 
 export const mutations = {

--- a/src/app/static/src/store/state.ts
+++ b/src/app/static/src/store/state.ts
@@ -1,4 +1,4 @@
-import { ApiInfo, Data, Metadata } from "@/types";
+import {ApiInfo, Data, ErrorInfo, Metadata} from "@/types";
 
 export interface RootState {
   apiInfo: ApiInfo | null
@@ -6,4 +6,5 @@ export interface RootState {
   results: Data | null
   paramValues: Data | null
   fetchingResults: boolean
+  errors: Array<ErrorInfo>
 }

--- a/src/app/static/src/store/state.ts
+++ b/src/app/static/src/store/state.ts
@@ -1,4 +1,9 @@
-import {ApiInfo, Data, ErrorInfo, Metadata} from "@/types";
+import {
+    ApiInfo,
+    Data,
+    ErrorInfo,
+    Metadata
+} from "@/types";
 
 export interface RootState {
   apiInfo: ApiInfo | null

--- a/src/app/static/src/types.ts
+++ b/src/app/static/src/types.ts
@@ -50,3 +50,8 @@ export interface Metadata {
 export interface Data {
   [k: string]: unknown;
 }
+
+export interface ErrorInfo {
+  error: string,
+  detail: string
+}

--- a/src/app/static/src/types.ts
+++ b/src/app/static/src/types.ts
@@ -53,5 +53,5 @@ export interface Data {
 
 export interface ErrorInfo {
   error: string,
-  detail: string
+  detail?: string
 }

--- a/src/app/static/src/views/About.vue
+++ b/src/app/static/src/views/About.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="about">
     <h1>{{ heading }}</h1>
+    <errors :errors="errors" @dismissed="setErrors([])"></errors>
     <h2>API versions</h2>
     <p>API Name: {{apiName}}</p>
     <div v-for="(value, key) in apiVersion" :key="key">{{key}}: {{value}}</div>
@@ -9,19 +10,24 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { mapActions, mapState } from "vuex";
+import { mapActions, mapState, mapMutations } from "vuex";
+import Errors from "@/components/Errors.vue";
 
 export default Vue.extend({
     name: "About",
     props: {
         heading: {
             type: String,
-            default: "This is an about page"
+            default: "About comet"
         }
+    },
+    components: {
+        Errors
     },
     computed: {
         ...mapState([
-            "apiInfo"
+            "apiInfo",
+            "errors"
         ]),
         apiName(): string {
             return this.apiInfo && this.apiInfo.name;
@@ -33,6 +39,9 @@ export default Vue.extend({
     methods: {
         ...mapActions([
             "getApiInfo"
+        ]),
+        ...mapMutations([
+            "setErrors"
         ])
     },
     mounted() {

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -68,8 +68,12 @@ export default defineComponent({
         ])
     },
     mounted() {
-        this.getMetadata();
-        this.getResults();
+        if (!this.metadata) {
+            this.getMetadata();
+        }
+        if (!this.results) {
+            this.getResults();
+        }
     }
 });
 </script>

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="home row">
     <div class="col-md-4">
-      <Errors :errors="errors"></Errors>
       <Parameters v-if="metadata"
                   :paramGroupMetadata="metadata.parameterGroups"
                   :paramValues="paramValues"
@@ -9,6 +8,7 @@
                   @updateValues="updateParameterValues"></Parameters>
     </div>
     <div class="col-md-8">
+      <Errors :errors="errors"></Errors>
       <Charts v-if="metadata && !fetchingResults"
               :chart-metadata="metadata.charts"
               :chart-data="results"

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="home row">
-    <Parameters class="col-md-4" v-if="metadata"
-                :paramGroupMetadata="metadata.parameterGroups"
-                :paramValues="paramValues"
-                @updateMetadata="setParameterMetadata"
-                @updateValues="updateParameterValues"></Parameters>
+    <div class="col-md-4">
+      <Errors :errors="errors"></Errors>
+      <Parameters v-if="metadata"
+                  :paramGroupMetadata="metadata.parameterGroups"
+                  :paramValues="paramValues"
+                  @updateMetadata="setParameterMetadata"
+                  @updateValues="updateParameterValues"></Parameters>
+    </div>
     <div class="col-md-8">
       <Charts v-if="metadata && !fetchingResults"
               :chart-metadata="metadata.charts"
@@ -31,12 +34,14 @@ import {
     mapMutations,
     mapState
 } from "vuex";
+import Errors from "@/components/Errors.vue";
 
 export default defineComponent({
     name: "Home",
     components: {
         Charts,
         Parameters,
+        Errors,
         LoadingSpinner
     },
     computed: {
@@ -44,7 +49,8 @@ export default defineComponent({
             "metadata",
             "paramValues",
             "results",
-            "fetchingResults"
+            "fetchingResults",
+            "errors"
         ]),
         ...mapGetters([
             "chartLayoutData"

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -8,7 +8,7 @@
                   @updateValues="updateParameterValues"></Parameters>
     </div>
     <div class="col-md-8">
-      <Errors :errors="errors"></Errors>
+      <Errors :errors="errors" @dismissed="setErrors([])"></Errors>
       <Charts v-if="metadata && !fetchingResults"
               :chart-metadata="metadata.charts"
               :chart-data="results"
@@ -63,7 +63,8 @@ export default defineComponent({
             "updateParameterValues"
         ]),
         ...mapMutations([
-            "setParameterMetadata"
+            "setParameterMetadata",
+            "setErrors"
         ])
     },
     mounted() {

--- a/src/app/static/tests/mocks.ts
+++ b/src/app/static/tests/mocks.ts
@@ -32,6 +32,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         results: null,
         paramValues: null,
         fetchingResults: false,
+        errors: [],
         ...state
     };
 }

--- a/src/app/static/tests/unit/components/errors.test.ts
+++ b/src/app/static/tests/unit/components/errors.test.ts
@@ -1,16 +1,16 @@
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import Vue from "vue";
 import Errors from "@/components/Errors.vue";
-import {BAlert} from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 
 describe("Errors", () => {
     it("renders as expected with one errors", () => {
         const propsData = {
-          errors: [
-            {error: "ERROR_1", detail: "first error"}
-          ]
+            errors: [
+                { error: "ERROR_1", detail: "first error" }
+            ]
         };
-        const wrapper = shallowMount(Errors, {propsData});
+        const wrapper = shallowMount(Errors, { propsData });
         const alert = wrapper.findComponent(BAlert);
         expect(alert.props("variant")).toBe("danger");
         expect(alert.props("show")).toBe(true);
@@ -25,11 +25,11 @@ describe("Errors", () => {
     it("renders as expected with two errors", () => {
         const propsData = {
             errors: [
-                { error: "ERROR_1", detail: "first error"},
+                { error: "ERROR_1", detail: "first error" },
                 { error: "ERROR_2" }
             ]
         };
-        const wrapper = shallowMount(Errors, {propsData});
+        const wrapper = shallowMount(Errors, { propsData });
         const alert = wrapper.findComponent(BAlert);
         expect(alert.props("variant")).toBe("danger");
         expect(alert.props("show")).toBe(true);
@@ -43,19 +43,19 @@ describe("Errors", () => {
     });
 
     it("renders no alert if errors is empty", () => {
-        const propsData = { errors:[] };
-        const wrapper = shallowMount(Errors, {propsData});
+        const propsData = { errors: [] };
+        const wrapper = shallowMount(Errors, { propsData });
         const alert = wrapper.findComponent(BAlert);
         expect(alert.exists()).toBe(false);
     });
 
     it("emits dismissed event", async () => {
         const propsData = {
-          errors: [
-            {error: "ERROR_1", detail: "first error"}
-          ]
+            errors: [
+                { error: "ERROR_1", detail: "first error" }
+            ]
         };
-        const wrapper = shallowMount(Errors, {propsData});
+        const wrapper = shallowMount(Errors, { propsData });
         const alert = wrapper.findComponent(BAlert);
         alert.vm.$emit("dismissed");
         await Vue.nextTick();

--- a/src/app/static/tests/unit/components/errors.test.ts
+++ b/src/app/static/tests/unit/components/errors.test.ts
@@ -4,7 +4,7 @@ import Errors from "@/components/Errors.vue";
 import { BAlert } from "bootstrap-vue";
 
 describe("Errors", () => {
-    it("renders as expected with one errors", () => {
+    it("renders as expected with one error", () => {
         const propsData = {
             errors: [
                 { error: "ERROR_1", detail: "first error" }

--- a/src/app/static/tests/unit/components/errors.test.ts
+++ b/src/app/static/tests/unit/components/errors.test.ts
@@ -1,0 +1,64 @@
+import {shallowMount} from "@vue/test-utils";
+import Vue from "vue";
+import Errors from "@/components/Errors.vue";
+import {BAlert} from "bootstrap-vue";
+
+describe("Errors", () => {
+    it("renders as expected with one errors", () => {
+        const propsData = {
+          errors: [
+            {error: "ERROR_1", detail: "first error"}
+          ]
+        };
+        const wrapper = shallowMount(Errors, {propsData});
+        const alert = wrapper.findComponent(BAlert);
+        expect(alert.props("variant")).toBe("danger");
+        expect(alert.props("show")).toBe(true);
+        expect(alert.props("dismissible")).toBe(true);
+        expect(alert.find("strong").text()).toBe("An error occurred:");
+
+        const items = alert.findAll("li");
+        expect(items.length).toBe(1);
+        expect(items.at(0).text()).toBe("first error");
+    });
+
+    it("renders as expected with two errors", () => {
+        const propsData = {
+            errors: [
+                { error: "ERROR_1", detail: "first error"},
+                { error: "ERROR_2" }
+            ]
+        };
+        const wrapper = shallowMount(Errors, {propsData});
+        const alert = wrapper.findComponent(BAlert);
+        expect(alert.props("variant")).toBe("danger");
+        expect(alert.props("show")).toBe(true);
+        expect(alert.props("dismissible")).toBe(true);
+        expect(alert.find("strong").text()).toBe("Errors occurred:");
+
+        const items = alert.findAll("li");
+        expect(items.length).toBe(2);
+        expect(items.at(0).text()).toBe("first error");
+        expect(items.at(1).text()).toBe("ERROR_2");
+    });
+
+    it("renders no alert if errors is empty", () => {
+        const propsData = { errors:[] };
+        const wrapper = shallowMount(Errors, {propsData});
+        const alert = wrapper.findComponent(BAlert);
+        expect(alert.exists()).toBe(false);
+    });
+
+    it("emits dismissed event", async () => {
+        const propsData = {
+          errors: [
+            {error: "ERROR_1", detail: "first error"}
+          ]
+        };
+        const wrapper = shallowMount(Errors, {propsData});
+        const alert = wrapper.findComponent(BAlert);
+        alert.vm.$emit("dismissed");
+        await Vue.nextTick();
+        expect(wrapper.emitted("dismissed")!.length).toBe(1);
+    });
+});

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -1,5 +1,10 @@
 import { actions } from "@/store/actions";
-import {mockAxios, mockFailure, mockRootState, mockSuccess} from "../../mocks";
+import {
+    mockAxios,
+    mockFailure,
+    mockRootState,
+    mockSuccess
+} from "../../mocks";
 
 describe("actions", () => {
     beforeEach(() => {
@@ -71,19 +76,19 @@ describe("actions", () => {
 
     it("get metadata commits errors", async () => {
         mockAxios.onGet("/metadata")
-          .reply(400, mockFailure("Metadata failed"));
+            .reply(400, mockFailure("Metadata failed"));
 
         const commit = jest.fn();
         await (actions.getMetadata as any)({ commit });
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0]).toBe("setErrors");
         expect(commit.mock.calls[0][1]).toStrictEqual(
-          [{error: "OTHER_ERROR", detail: "Metadata failed"}]);
+            [{ error: "OTHER_ERROR", detail: "Metadata failed" }]
+        );
     });
 
     it("get results commits errors", async () => {
-        mockAxios.onPost("/results")
-          .networkError();
+        mockAxios.onPost("/results").networkError();
 
         const commit = jest.fn();
         const state = mockRootState();
@@ -95,7 +100,7 @@ describe("actions", () => {
         expect(commit.mock.calls[1][0]).toBe("setErrors");
         expect(commit.mock.calls[1][1]).toStrictEqual([]);
         expect(commit.mock.calls[2][0]).toBe("setErrors");
-        expect(commit.mock.calls[2][1]).toStrictEqual([{error: "Network Error"}]);
+        expect(commit.mock.calls[2][1]).toStrictEqual([{ error: "Network Error" }]);
         expect(commit.mock.calls[3][0]).toBe("setFetchingResults");
         expect(commit.mock.calls[3][1]).toBe(false);
     });
@@ -105,6 +110,8 @@ describe("actions", () => {
         await (actions.getApiInfo as any)({ commit });
         expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0]).toBe("setErrors");
-        expect(commit.mock.calls[0][1]).toStrictEqual([{error: "Request failed with status code 404"}]);
+        expect(commit.mock.calls[0][1]).toStrictEqual([
+            { error: "Request failed with status code 404" }
+        ]);
     });
 });

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -1,4 +1,4 @@
-import { actions } from "@/store/actions";
+import { actions, commitErrors } from "@/store/actions";
 import {
     mockAxios,
     mockFailure,
@@ -87,6 +87,23 @@ describe("actions", () => {
         );
     });
 
+    it("gets api info", async () => {
+        const mockApiInfo = {
+            name: "cometr",
+            version: {
+                cometr: "0.1.0",
+                nimue: "0.2.0"
+            }
+        };
+        mockAxios.onGet("/api-info")
+            .reply(200, mockSuccess(mockApiInfo));
+        const commit = jest.fn();
+        await (actions.getApiInfo as any)({ commit });
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe("setApiInfo");
+        expect(commit.mock.calls[0][1]).toStrictEqual(mockApiInfo);
+    });
+
     it("get results commits errors", async () => {
         mockAxios.onPost("/results").networkError();
 
@@ -112,6 +129,16 @@ describe("actions", () => {
         expect(commit.mock.calls[0][0]).toBe("setErrors");
         expect(commit.mock.calls[0][1]).toStrictEqual([
             { error: "Request failed with status code 404" }
+        ]);
+    });
+
+    it("commitErrors commits empty error", () => {
+        const commit = jest.fn();
+        commitErrors({} as any, commit);
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe("setErrors");
+        expect(commit.mock.calls[0][1]).toStrictEqual([
+            { error: "Unable to contact server" }
         ]);
     });
 });

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -141,4 +141,20 @@ describe("actions", () => {
             { error: "Unable to contact server" }
         ]);
     });
+
+    it("commitErrors commits 'error' on response data'", () => {
+        const commit = jest.fn();
+        commitErrors({
+            response: {
+                data: {
+                    error: "Test Error"
+                }
+            }
+        } as any, commit);
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe("setErrors");
+        expect(commit.mock.calls[0][1]).toStrictEqual([
+            { error: "Test Error" }
+        ]);
+    });
 });

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -41,4 +41,11 @@ describe("mutations", () => {
         mutations.setFetchingResults(state, true);
         expect(state.fetchingResults).toBe(true);
     });
+
+    it("sets errors", () => {
+        const state = mockRootState();
+        const errors = [{ error: "an error" }];
+        mutations.setErrors(state, errors);
+        expect(state.errors).toBe(errors);
+    });
 });

--- a/src/app/static/tests/unit/views/about.test.ts
+++ b/src/app/static/tests/unit/views/about.test.ts
@@ -1,0 +1,30 @@
+import Vuex from "vuex";
+import {RootState} from "@/store/state";
+import {mockRootState} from "../../mocks";
+import {shallowMount} from "@vue/test-utils";
+import Vue from "vue";
+import About from "@/views/About.vue";
+import Errors from "@/components/Errors.vue";
+
+describe("About", () => {
+    it("renders errors, and sets errors to empty when dismissed from Errors component",
+      async () => {
+          const mockSetErrors = jest.fn();
+          const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+              errors: [{error: "an error"}]
+            }),
+            mutations: {
+              setErrors: mockSetErrors
+            }
+          });
+          const wrapper = shallowMount(About, { store });
+          const errors = wrapper.findComponent(Errors);
+          expect(errors.props("errors")).toBe(store.state.errors);
+
+          errors.vm.$emit("dismissed");
+          await Vue.nextTick();
+          expect(mockSetErrors.mock.calls.length).toBe(1);
+          expect(mockSetErrors.mock.calls[0][1]).toStrictEqual([]);
+    });
+});

--- a/src/app/static/tests/unit/views/about.test.ts
+++ b/src/app/static/tests/unit/views/about.test.ts
@@ -1,30 +1,29 @@
 import Vuex from "vuex";
-import {RootState} from "@/store/state";
-import {mockRootState} from "../../mocks";
-import {shallowMount} from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import { shallowMount } from "@vue/test-utils";
 import Vue from "vue";
 import About from "@/views/About.vue";
 import Errors from "@/components/Errors.vue";
+import { mockRootState } from "../../mocks";
 
 describe("About", () => {
-    it("renders errors, and sets errors to empty when dismissed from Errors component",
-      async () => {
-          const mockSetErrors = jest.fn();
-          const store = new Vuex.Store<RootState>({
+    it("renders and dismisses errors", async () => {
+        const mockSetErrors = jest.fn();
+        const store = new Vuex.Store<RootState>({
             state: mockRootState({
-              errors: [{error: "an error"}]
+                errors: [{ error: "an error" }]
             }),
             mutations: {
-              setErrors: mockSetErrors
+                setErrors: mockSetErrors
             }
-          });
-          const wrapper = shallowMount(About, { store });
-          const errors = wrapper.findComponent(Errors);
-          expect(errors.props("errors")).toBe(store.state.errors);
+        });
+        const wrapper = shallowMount(About, { store });
+        const errors = wrapper.findComponent(Errors);
+        expect(errors.props("errors")).toBe(store.state.errors);
 
-          errors.vm.$emit("dismissed");
-          await Vue.nextTick();
-          expect(mockSetErrors.mock.calls.length).toBe(1);
-          expect(mockSetErrors.mock.calls[0][1]).toStrictEqual([]);
+        errors.vm.$emit("dismissed");
+        await Vue.nextTick();
+        expect(mockSetErrors.mock.calls.length).toBe(1);
+        expect(mockSetErrors.mock.calls[0][1]).toStrictEqual([]);
     });
 });

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -32,6 +32,48 @@ describe("Home", () => {
         expect(mockGetResults.mock.calls.length).toBe(1);
     });
 
+    it("does not get metadata if already set", () => {
+        const mockGetMetadata = jest.fn();
+        const mockGetResults = jest.fn();
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                metadata: {
+                    charts: []
+                } as any
+            }),
+            actions: {
+                getMetadata: mockGetMetadata,
+                getResults: mockGetResults
+            }
+        });
+
+        shallowMount(Home, { store });
+
+        expect(mockGetMetadata.mock.calls.length).toBe(0);
+        expect(mockGetResults.mock.calls.length).toBe(1);
+    });
+
+    it("does not get results if already set", () => {
+        const mockGetMetadata = jest.fn();
+        const mockGetResults = jest.fn();
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                results: {
+                    timeSeries: []
+                } as any
+            }),
+            actions: {
+                getMetadata: mockGetMetadata,
+                getResults: mockGetResults
+            }
+        });
+
+        shallowMount(Home, { store });
+
+        expect(mockGetMetadata.mock.calls.length).toBe(1);
+        expect(mockGetResults.mock.calls.length).toBe(0);
+    });
+
     it("renders Charts and Parameters component with expected props", () => {
         const store = new Vuex.Store<RootState>({
             state: mockRootState({

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -148,12 +148,11 @@ describe("Home", () => {
         expect(mockUpdateParameterValues.mock.calls[0][1]).toBe(mockParameterValues);
     });
 
-    it("renders errors, and sets errors to empty when dismissed from Errors component",
-        async () => {
+    it("renders and dismissed errors", async () => {
         const mockSetErrors = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-                errors: [{error: "an error"}]
+                errors: [{ error: "an error" }]
             }),
             mutations: {
                 setErrors: mockSetErrors

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -9,6 +9,7 @@ import { shallowMount } from "@vue/test-utils";
 import Home from "@/views/Home.vue";
 import Charts from "@/components/charts/Charts.vue";
 import Parameters from "@/components/parameters/Parameters.vue";
+import Errors from "@/components/Errors.vue";
 import { RootState } from "@/store/state";
 import { getters } from "@/store";
 import { mockRootState } from "../../mocks";
@@ -145,5 +146,26 @@ describe("Home", () => {
         await Vue.nextTick();
         expect(mockUpdateParameterValues.mock.calls.length).toBe(1);
         expect(mockUpdateParameterValues.mock.calls[0][1]).toBe(mockParameterValues);
+    });
+
+    it("renders errors, and sets errors to empty when dismissed from Errors component",
+        async () => {
+        const mockSetErrors = jest.fn();
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                errors: [{error: "an error"}]
+            }),
+            mutations: {
+                setErrors: mockSetErrors
+            }
+        });
+        const wrapper = shallowMount(Home, { store });
+        const errors = wrapper.findComponent(Errors);
+        expect(errors.props("errors")).toBe(store.state.errors);
+
+        errors.vm.$emit("dismissed");
+        await Vue.nextTick();
+        expect(mockSetErrors.mock.calls.length).toBe(1);
+        expect(mockSetErrors.mock.calls[0][1]).toStrictEqual([]);
     });
 });

--- a/src/config/cometr_version
+++ b/src/config/cometr_version
@@ -1,1 +1,1 @@
-master
+main

--- a/src/config/cometr_version
+++ b/src/config/cometr_version
@@ -1,1 +1,1 @@
-basic-run
+master


### PR DESCRIPTION
Adds some basic error handling to the api calls. If errors are encountered these are saved to the state, and displayed in a dismissible Errors component. Errors are cleared when user dismisses them, and also when results are re-fetched. 

Errors is displayed in both Home view and About view (we might encounter new errors in About if the call to `/api-info` fails. 

Not sure if this is entirely the right approach, comments welcome!

To test, there is a handy parameter which causes a nimue error: set 'Prioritisation & Allocation' to 'HCW, Elderly and High-RIsk Groups'. 