### PR TITLE
mrc-2418 Read-only phases view

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -7542,6 +7542,11 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -15,6 +15,7 @@
     "ajv": "^8.2.0",
     "axios": "^0.21.1",
     "bootstrap-vue": "^2.21.2",
+    "dayjs": "^1.10.4",
     "core-js": "^3.6.5",
     "jsonata": "^1.8.4",
     "plotly.js": "^1.58.4",

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -13,25 +13,36 @@ $theme-blue: #003e74;
 
   .parameter-panel {
     background-color: #fafafa;
-    padding-left: 1rem;
 
-    .dynamic-form {
-      .row {
-        label {
-          max-width: 60%;
-          flex: 0 0 60%;
+    .standard-parameters {
+      padding-left: 1rem;
+
+      .dynamic-form {
+        .row {
+          label {
+            max-width: 60%;
+            flex: 0 0 60%;
+          }
+
+          & > div {
+            max-width: 40%;
+            flex: 0 0 40%;
+          }
+
+          .dynamic-form-readonly-value {
+            padding-top: 7px;
+          }
+
         }
-
-        & > div {
-          max-width: 40%;
-          flex: 0 0 40%;
-        }
-
-        .dynamic-form-readonly-value {
-          padding-top: 7px;
-        }
-
       }
+    }
+
+    .phase-odd {
+      background-color: #d4effc;
+    }
+
+    .phase-even {
+      background-color: #ffe4e4;
     }
   }
 

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -37,12 +37,29 @@ $theme-blue: #003e74;
       }
     }
 
+    .phase-block-container {
+      position: relative;
+      width: 100%;
+      height: 5rem;
+    }
+
+    .phase-block {
+      position: absolute;
+      bottom: 0px;
+    }
+
     .phase-odd {
       background-color: #d4effc;
     }
 
     .phase-even {
       background-color: #ffe4e4;
+    }
+
+    .phase-block-base {
+      width: 100%;
+      height: 0.1rem;
+      background-color: #555555;
     }
   }
 

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -40,7 +40,7 @@ $theme-blue: #003e74;
     .phase-block-container {
       position: relative;
       width: 100%;
-      height: 5rem;
+      height: 3rem;
     }
 
     .phase-block {
@@ -59,7 +59,7 @@ $theme-blue: #003e74;
     .phase-block-base {
       width: 100%;
       height: 0.1rem;
-      background-color: #555555;
+      background-color: #ccc;
     }
   }
 

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -4,7 +4,7 @@
       <div>
         <collapsible class="collapsible mt-2" :initial-open="false" :heading="paramGroup.label">
           <div class="parameter-panel">
-            <div v-if="paramGroup.type == 'dynamicForm'" class="standard-parameters">
+            <div v-if="paramGroup.type === 'dynamicForm'" class="standard-parameters">
               <dynamic-form v-model="paramGroup.config"
                           :readonly="true"></dynamic-form>
               <button class="btn btn-action float-right mb-3 mr-3"
@@ -12,7 +12,7 @@
               <span class="clearfix"></span>
             </div>
             <phases
-              v-if="paramGroup.type == 'rt'"
+              v-if="paramGroup.type === 'rt'"
               :phases="paramGroup.config"
               :forecastEnd="forecastEnd"
               :forecastStart="forecastStart"
@@ -43,7 +43,7 @@ import EditParameters from "./EditParameters.vue";
 import Phases from "./Phases.vue";
 
 interface Props {
-    paramGroupMetadata: Array<ParameterGroupMetadata>
+    paramGroupMetadata: ParameterGroupMetadata[]
     paramValues: Data
     forecastStart: Date
     forecastEnd: Date

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,15 +1,17 @@
 <template>
   <div>
     <div v-for="paramGroup in paramGroupMetadata" :key="paramGroup.id">
-      <div v-if="paramGroup.type == 'dynamicForm'">
+      <div>
         <collapsible class="collapsible mt-2" :initial-open="false" :heading="paramGroup.label">
           <div class="parameter-panel">
-            <dynamic-form v-if="paramGroup.type == 'dynamicForm'"
-                        v-model="paramGroup.config"
-                        :readonly="true"></dynamic-form>
-            <button class="btn btn-action float-right mb-3 mr-3"
-                    @click="editParameters(paramGroup.id)">Edit</button>
-            <span class="clearfix"></span>
+            <div v-if="paramGroup.type == 'dynamicForm'">
+              <dynamic-form v-model="paramGroup.config"
+                          :readonly="true"></dynamic-form>
+              <button class="btn btn-action float-right mb-3 mr-3"
+                      @click="editParameters(paramGroup.id)">Edit</button>
+              <span class="clearfix"></span>
+            </div>
+            <phases v-if="paramGroup.type == 'rt'" phases="paramGroup.config"></phases>
           </div>
         </collapsible>
       </div>

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -4,7 +4,7 @@
       <div>
         <collapsible class="collapsible mt-2" :initial-open="false" :heading="paramGroup.label">
           <div class="parameter-panel">
-            <div v-if="paramGroup.type == 'dynamicForm'">
+            <div v-if="paramGroup.type == 'dynamicForm'" class="standard-parameters">
               <dynamic-form v-model="paramGroup.config"
                           :readonly="true"></dynamic-form>
               <button class="btn btn-action float-right mb-3 mr-3"
@@ -15,6 +15,7 @@
               v-if="paramGroup.type == 'rt'"
               :phases="paramGroup.config"
               :forecastEnd="forecastEnd"
+              :forecastStart="forecastStart"
             ></phases>
           </div>
         </collapsible>
@@ -44,6 +45,7 @@ import Phases from "./Phases.vue";
 interface Props {
     paramGroupMetadata: Array<ParameterGroupMetadata>
     paramValues: Data
+    forecastStart: Date
     forecastEnd: Date
 }
 
@@ -58,6 +60,7 @@ export default defineComponent({
     props: {
         paramGroupMetadata: Array,
         paramValues: Object,
+        forecastStart: Date,
         forecastEnd: Date
     },
     setup(props: Props, context) {

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -11,7 +11,11 @@
                       @click="editParameters(paramGroup.id)">Edit</button>
               <span class="clearfix"></span>
             </div>
-            <phases v-if="paramGroup.type == 'rt'" phases="paramGroup.config"></phases>
+            <phases
+              v-if="paramGroup.type == 'rt'"
+              :phases="paramGroup.config"
+              :forecastEnd="forecastEnd"
+            ></phases>
           </div>
         </collapsible>
       </div>
@@ -35,10 +39,12 @@ import {
 import { Data, ParameterGroupMetadata } from "@/types";
 import Collapsible from "@/components/Collapsible.vue";
 import EditParameters from "./EditParameters.vue";
+import Phases from "./Phases.vue";
 
 interface Props {
     paramGroupMetadata: Array<ParameterGroupMetadata>
     paramValues: Data
+    forecastEnd: Date
 }
 
 export default defineComponent({
@@ -46,11 +52,13 @@ export default defineComponent({
     components: {
         DynamicForm,
         EditParameters,
-        Collapsible
+        Collapsible,
+        Phases
     },
     props: {
         paramGroupMetadata: Array,
-        paramValues: Object
+        paramValues: Object,
+        forecastEnd: Date
     },
     setup(props: Props, context) {
         const modalOpen = ref(false);

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -12,11 +12,13 @@
     <div class="phase-block-base"></div>
     <div v-for="phase in displayPhases"
          :key="phase.index"
-         class="p-2 mt-2"
+         class="phase-description p-2 mt-2"
          :class="phaseClassFromIndex(phase.index)">
-      <span class="font-weight-bold">Phase {{phase.index}}</span> ({{phase.days}} days)
-      <div class="mb-3">{{phase.start}} - {{phase.end}}</div>
-      <div>Rt: <span class="font-weight-bold">{{phase.value}}</span></div>
+      <div class="phase-header">
+        <span class="font-weight-bold">Phase {{phase.index}}</span> ({{phase.days}} days)
+      </div>
+      <div class="phase-dates mb-3">{{phase.start}} - {{phase.end}}</div>
+      <div class="phase-rt">Rt: <span class="font-weight-bold">{{phase.value}}</span></div>
     </div>
   </div>
 </template>
@@ -72,7 +74,7 @@ export default defineComponent({
                 endDate = dayjs(props.forecastEnd);
             }
 
-            const days = daysBetween(startDate, endDate);
+            const days = daysBetween(startDate, endDate) + 1; // include last day
             const format = "DD/MM/YY";
 
             return {
@@ -85,7 +87,7 @@ export default defineComponent({
             };
         });
 
-        const totalDays = daysBetween(props.forecastStart, props.forecastEnd);
+        const totalDays = daysBetween(props.forecastStart, props.forecastEnd) + 1;
         const daysAsPercent = (days: number) => (days / totalDays) * 100;
 
         const maxRt = Math.max(...props.phases.map((p) => parseFloat(p.value)));

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -11,7 +11,8 @@ dayjs.extend(duration);
 
 interface Props {
     phases: Array<Rt>,
-    forecastDays: number
+    forecastStart: Date,
+    forecastEnd: Date
 }
 
 interface displayPhase {
@@ -30,22 +31,14 @@ export default defineComponent({
     },
     setup(props: Props) {
         const displayPhases = props.phases.map((rt, idx) => {
-            //const startDate = new Date(Date.parse(rt.start));
             const startDate = dayjs(rt.start);
             let endDate;
             if (idx < props.phases.length - 1) {
-                //const nextStart = Date.parse(props.phases[idx + 1].start);
-                //const nextStart = ;
-                //endDate = new Date(nextStart);
-                //endDate.setDate(endDate.getDate() - 1);
                 endDate = dayjs(props.phases[idx + 1].start).subtract(1, "day");
             } else {
-                //endDate = new Date();
-                //endDate.setDate(endDate.getDate() + props.forecastDays);
-                endDate = dayjs().add(props.forecastDays, "day");
+                endDate = props.forecastEnd;
             }
 
-            //const days = endDate === startDate ? 0 : Math.floor((endDate.valueOf() - startDate.valueOf())/(1000*60*60*24));
             const days = startDate.diff(endDate, "day");
             const format = "DD/MM/YY";
 
@@ -55,8 +48,11 @@ export default defineComponent({
                 start: startDate.format(format),
                 end: endDate.format(format),
                 value: rt.value
-            }
-       });
+            };
+        });
+        return {
+            displayPhases
+        };
     }
 });
 </script>

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -1,5 +1,11 @@
 <template>
-
+  <div>
+    <div v-for="phase in displayPhases" :key="phase.index">
+      <span class="font-weight-bold">Phase {{phase.index}}</span> ({{phase.days}} days)
+      <div class="mb-3">{{phase.start}}-{{phase.end}}</div>
+      <div>Rt: <span class="font-weight-bold">{{phase.value}}</span></div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -7,11 +13,11 @@ import { defineComponent } from "@vue/composition-api";
 import { Rt } from "@/types";
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
+
 dayjs.extend(duration);
 
 interface Props {
     phases: Array<Rt>,
-    forecastStart: Date,
     forecastEnd: Date
 }
 
@@ -27,7 +33,7 @@ export default defineComponent({
     name: "Phases",
     props: {
         phases: Array,
-        forecastDays: Number
+        forecastEnd: Date
     },
     setup(props: Props) {
         const displayPhases = props.phases.map((rt, idx) => {
@@ -36,7 +42,7 @@ export default defineComponent({
             if (idx < props.phases.length - 1) {
                 endDate = dayjs(props.phases[idx + 1].start).subtract(1, "day");
             } else {
-                endDate = props.forecastEnd;
+                endDate = dayjs(props.forecastEnd);
             }
 
             const days = startDate.diff(endDate, "day");

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -1,0 +1,62 @@
+<template>
+
+</template>
+
+<script lang="ts">
+import { defineComponent } from "@vue/composition-api";
+import { Rt } from "@/types";
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+dayjs.extend(duration);
+
+interface Props {
+    phases: Array<Rt>,
+    forecastDays: number
+}
+
+interface displayPhase {
+    index: number
+    days: number
+    start: string
+    end: string
+    value: number
+}
+
+export default defineComponent({
+    name: "Phases",
+    props: {
+        phases: Array,
+        forecastDays: Number
+    },
+    setup(props: Props) {
+        const displayPhases = props.phases.map((rt, idx) => {
+            //const startDate = new Date(Date.parse(rt.start));
+            const startDate = dayjs(rt.start);
+            let endDate;
+            if (idx < props.phases.length - 1) {
+                //const nextStart = Date.parse(props.phases[idx + 1].start);
+                //const nextStart = ;
+                //endDate = new Date(nextStart);
+                //endDate.setDate(endDate.getDate() - 1);
+                endDate = dayjs(props.phases[idx + 1].start).subtract(1, "day");
+            } else {
+                //endDate = new Date();
+                //endDate.setDate(endDate.getDate() + props.forecastDays);
+                endDate = dayjs().add(props.forecastDays, "day");
+            }
+
+            //const days = endDate === startDate ? 0 : Math.floor((endDate.valueOf() - startDate.valueOf())/(1000*60*60*24));
+            const days = startDate.diff(endDate, "day");
+            const format = "DD/MM/YY";
+
+            return {
+                index: idx + 1,
+                days,
+                start: startDate.format(format),
+                end: endDate.format(format),
+                value: rt.value
+            }
+       });
+    }
+});
+</script>

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <div v-for="phase in displayPhases" :key="phase.index">
+    <div v-for="phase in displayPhases"
+         :key="phase.index"
+         class="p-2 m-2"
+         :class="phase.index % 2 ? 'phase-odd' : 'phase-even'">
       <span class="font-weight-bold">Phase {{phase.index}}</span> ({{phase.days}} days)
       <div class="mb-3">{{phase.start}}-{{phase.end}}</div>
       <div>Rt: <span class="font-weight-bold">{{phase.value}}</span></div>
@@ -18,21 +21,32 @@ dayjs.extend(duration);
 
 interface Props {
     phases: Array<Rt>,
+    forecastStart: Date,
     forecastEnd: Date
 }
 
 interface displayPhase {
     index: number
     days: number
+    startDate: Date,
+    endDate: Date,
     start: string
     end: string
     value: number
+}
+
+interface phaseBlock {
+    index: number
+    width: number,
+    left: number,
+    height: number
 }
 
 export default defineComponent({
     name: "Phases",
     props: {
         phases: Array,
+        forecastStart: Date,
         forecastEnd: Date
     },
     setup(props: Props) {
@@ -45,19 +59,46 @@ export default defineComponent({
                 endDate = dayjs(props.forecastEnd);
             }
 
-            const days = startDate.diff(endDate, "day");
+            const days = endDate.diff(startDate, "day");
             const format = "DD/MM/YY";
 
             return {
                 index: idx + 1,
                 days,
+                startDate,
+                endDate,
                 start: startDate.format(format),
                 end: endDate.format(format),
                 value: rt.value
             };
         });
+
+        const totalDays = dayjs(props.forecastEnd).diff(dayjs(props.forecastStart, "day"));
+        const daysAsPercent = (days: number) => {
+            return (days / totalDays) * 100;
+        };
+
+        const maxRt = Math.max(...props.phases.map(p => parseFloat(p.value));
+        const rtAsPercent = (rt: number) => {
+            return (rt / maxRt) * 100''
+        };
+
+        let lastRight = daysAsPercent(dayjs(displayPhases[0].startDate).diff(dayjs(props.forecastStart, "day")));
+        const phaseBlocks = displayPhases.map((displayPhase) => {
+            const result = {
+                index: displayPhase.index,
+                left: lastRight,
+                width: daysAsPercent(displayPhase.days),
+                height: rtAsPercent(parseFloat(displayPhase.value))
+            };
+            lastRight += result.width;
+
+            return result;
+        });
+
         return {
-            displayPhases
+            displayPhases,
+            phaseBlocks
         };
     }
 });

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -32,7 +32,7 @@ import duration from "dayjs/plugin/duration";
 dayjs.extend(duration);
 
 interface Props {
-    phases: Array<Rt>,
+    phases: Rt[],
     forecastStart: Date,
     forecastEnd: Date
 }
@@ -65,7 +65,7 @@ export default defineComponent({
             return dayjs(end).diff(dayjs(start), "day");
         };
 
-        const displayPhases: Array<DisplayPhase> = props.phases.map((rt, idx) => {
+        const displayPhases: DisplayPhase[] = props.phases.map((rt, idx) => {
             const startDate = dayjs(rt.start);
             let endDate;
             if (idx < props.phases.length - 1) {
@@ -96,7 +96,7 @@ export default defineComponent({
         const formatPercent = (value: number) => `${value.toFixed(2)}%`;
 
         let nextLeft = daysAsPercent(daysBetween(props.forecastStart, displayPhases[0].startDate));
-        const phaseBlocks: Array<PhaseBlock> = displayPhases.map((displayPhase) => {
+        const phaseBlocks: PhaseBlock[] = displayPhases.map((displayPhase) => {
             const width = daysAsPercent(displayPhase.days);
             const result = {
                 index: displayPhase.index,

--- a/src/app/static/src/components/parameters/Phases.vue
+++ b/src/app/static/src/components/parameters/Phases.vue
@@ -1,9 +1,19 @@
 <template>
   <div>
+    <div class="phase-block-container">
+      <div
+        v-for="phaseBlock in phaseBlocks"
+        :key="phaseBlock.index"
+        class="phase-block"
+        :class="phaseClassFromIndex(phaseBlock.index)"
+        :style="`height:${phaseBlock.height}%; width:${phaseBlock.width}%; left: ${phaseBlock.left}%`"
+      ></div>
+    </div>
+    <div class="phase-block-base mb-2"></div>
     <div v-for="phase in displayPhases"
          :key="phase.index"
          class="p-2 m-2"
-         :class="phase.index % 2 ? 'phase-odd' : 'phase-even'">
+         :class="phaseClassFromIndex(phase.index)">
       <span class="font-weight-bold">Phase {{phase.index}}</span> ({{phase.days}} days)
       <div class="mb-3">{{phase.start}}-{{phase.end}}</div>
       <div>Rt: <span class="font-weight-bold">{{phase.value}}</span></div>
@@ -73,32 +83,37 @@ export default defineComponent({
             };
         });
 
-        const totalDays = dayjs(props.forecastEnd).diff(dayjs(props.forecastStart, "day"));
-        const daysAsPercent = (days: number) => {
-            return (days / totalDays) * 100;
-        };
+        alert(props.forecastStart)
+        alert(props.forecastEnd)
+        const totalDays = dayjs(props.forecastEnd).diff(dayjs(props.forecastStart), "day");
+        alert("totalDays: " + totalDays)
+        const daysAsPercent = (days: number) => (days / totalDays) * 100;
 
-        const maxRt = Math.max(...props.phases.map(p => parseFloat(p.value));
-        const rtAsPercent = (rt: number) => {
-            return (rt / maxRt) * 100''
-        };
+        const maxRt = Math.max(...props.phases.map(p => parseFloat(p.value)));
+        const rtAsPercent = (rt: number) => (rt / maxRt) * 100;
 
         let lastRight = daysAsPercent(dayjs(displayPhases[0].startDate).diff(dayjs(props.forecastStart, "day")));
         const phaseBlocks = displayPhases.map((displayPhase) => {
+            const width = daysAsPercent(displayPhase.days);
             const result = {
                 index: displayPhase.index,
-                left: lastRight,
-                width: daysAsPercent(displayPhase.days),
-                height: rtAsPercent(parseFloat(displayPhase.value))
+                left: lastRight.toFixed(2),
+                width: width.toFixed(2),
+                height: rtAsPercent(parseFloat(displayPhase.value)).toFixed(2)
             };
-            lastRight += result.width;
+            lastRight += width;
 
             return result;
         });
 
+        const phaseClassFromIndex = (index: number) => (index % 2 ? "phase-odd" : "phase-even");
+
+        alert(JSON.stringify(phaseBlocks));
+
         return {
             displayPhases,
-            phaseBlocks
+            phaseBlocks,
+            phaseClassFromIndex
         };
     }
 });

--- a/src/app/static/src/router/index.ts
+++ b/src/app/static/src/router/index.ts
@@ -2,7 +2,7 @@ import VueRouter, { RouteConfig } from "vue-router";
 import Vue from "vue";
 import Home from "../views/Home.vue";
 
-const routes: Array<RouteConfig> = [
+const routes: RouteConfig[] = [
     {
         path: "/",
         name: "Home",

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -5,7 +5,7 @@ import { ErrorInfo, ParameterGroupJsonataMetadata } from "@/types";
 import jsonata from "jsonata";
 
 export function commitErrors(e: AxiosError, commit: Commit): void {
-    let errors: Array<ErrorInfo>;
+    let errors: ErrorInfo[];
     if (e.response?.data?.errors) {
         errors = e.response.data.errors;
     } else if (e.response?.data?.error) {

--- a/src/app/static/src/store/getters.ts
+++ b/src/app/static/src/store/getters.ts
@@ -1,21 +1,22 @@
 import dayjs from "dayjs";
 import { RootState } from "@/store/state";
-import { forecastDays } from "@/store/index";
-import {Data} from "@/types";
+import { Data } from "@/types";
+
+export const forecastDays = 730;
 
 export const getters = {
     chartLayoutData: (state: RootState): Data => {
-      return {
-        params: state.paramValues,
-        // This is not a parameter, cannot be edited - will come from cometr regions endpoint
-        population: 67890000
-      };
+        return {
+            params: state.paramValues,
+            // This is not a parameter, cannot be edited - will come from cometr regions endpoint
+            population: 67890000
+        };
     },
-    forecastStart: (state: RootState) => {
+    forecastStart: (): Date => {
         // NB This will be updated from today to the day after last reporting day
-        return Date()
+        return new Date();
     },
-    forecastEnd: (state: RootState) => {
+    forecastEnd: (): Date => {
         // NB counting from today for now, but this will be updated to count from last reporting
         // day in country data
         return dayjs().add(forecastDays, "days").toDate();

--- a/src/app/static/src/store/getters.ts
+++ b/src/app/static/src/store/getters.ts
@@ -14,11 +14,11 @@ export const getters = {
     },
     forecastStart: (): Date => {
         // NB This will be updated from today to the day after last reporting day
-        return new Date();
+        return dayjs().startOf("day").toDate();
     },
     forecastEnd: (): Date => {
         // NB counting from today for now, but this will be updated to count from last reporting
         // day in country data
-        return dayjs().add(forecastDays, "days").toDate();
+        return dayjs().startOf("day").add(forecastDays, "days").toDate();
     }
 };

--- a/src/app/static/src/store/getters.ts
+++ b/src/app/static/src/store/getters.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { RootState } from "@/store/state";
 import { Data } from "@/types";
 
+// We hard-code this parameter sent to cometr to give a forecast of 2 years
 export const forecastDays = 730;
 
 export const getters = {

--- a/src/app/static/src/store/getters.ts
+++ b/src/app/static/src/store/getters.ts
@@ -13,12 +13,12 @@ export const getters = {
         };
     },
     forecastStart: (): Date => {
-        // NB This will be updated from today to the day after last reporting day
+        // NB This will be updated from today to the day after last reporting day  mrc-2442
         return dayjs().startOf("day").toDate();
     },
     forecastEnd: (): Date => {
         // NB counting from today for now, but this will be updated to count from last reporting
-        // day in country data
+        // day in country data in mrc-2442
         return dayjs().startOf("day").add(forecastDays, "days").toDate();
     }
 };

--- a/src/app/static/src/store/getters.ts
+++ b/src/app/static/src/store/getters.ts
@@ -1,0 +1,19 @@
+import dayjs from "dayjs";
+import { RootState } from "@/store/state";
+import { forecastDays } from "@/store/index";
+import {Data} from "@/types";
+
+export const getters = {
+    chartLayoutData: (state: RootState): Data => {
+      return {
+        params: state.paramValues,
+        // This is not a parameter, cannot be edited - will come from cometr regions endpoint
+        population: 67890000
+      };
+    },
+    forecastEnd: (state: RootState) => {
+        // NB counting from today for now, but this will be updated to count from last reporting
+        // day in country data
+        return dayjs().add(forecastDays, "days").toDate();
+    }
+};

--- a/src/app/static/src/store/getters.ts
+++ b/src/app/static/src/store/getters.ts
@@ -11,6 +11,10 @@ export const getters = {
         population: 67890000
       };
     },
+    forecastStart: (state: RootState) => {
+        // NB This will be updated from today to the day after last reporting day
+        return Date()
+    },
     forecastEnd: (state: RootState) => {
         // NB counting from today for now, but this will be updated to count from last reporting
         // day in country data

--- a/src/app/static/src/store/index.ts
+++ b/src/app/static/src/store/index.ts
@@ -1,15 +1,13 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import { actions } from "@/store/actions";
-import { getters } from "@/store/getters";
+import { getters, forecastDays } from "@/store/getters";
 import { mutations } from "@/store/mutations";
 import { RootState } from "@/store/state";
 import CompositionApi from "@vue/composition-api";
 
 Vue.use(Vuex);
 Vue.use(CompositionApi);
-
-export const forecastDays = 730;
 
 export default new Vuex.Store<RootState>({
     state: {

--- a/src/app/static/src/store/index.ts
+++ b/src/app/static/src/store/index.ts
@@ -1,23 +1,15 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import { actions } from "@/store/actions";
+import { getters } from "@/store/getters";
 import { mutations } from "@/store/mutations";
 import { RootState } from "@/store/state";
-import { Data } from "@/types";
 import CompositionApi from "@vue/composition-api";
 
 Vue.use(Vuex);
 Vue.use(CompositionApi);
 
-export const getters = {
-    chartLayoutData: (state: RootState): Data => {
-        return {
-            params: state.paramValues,
-            // This is not a parameter, cannot be edited - will come from cometr regions endpoint
-            population: 67890000
-        };
-    }
-};
+export const forecastDays = 730;
 
 export default new Vuex.Store<RootState>({
     state: {
@@ -53,7 +45,7 @@ export default new Vuex.Store<RootState>({
                 }
             ],
             simulation: {
-                forecastDays: 730
+                forecastDays
             }
         },
         fetchingResults: false

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -17,7 +17,7 @@ export const mutations = {
     setResults(state: RootState, results: Data): void {
         state.results = results;
     },
-    setParameterMetadata(state: RootState, paramMetadata: Array<ParameterGroupMetadata>): void {
+    setParameterMetadata(state: RootState, paramMetadata: ParameterGroupMetadata[]): void {
         state.metadata!.parameterGroups = paramMetadata;
     },
     setParameterValues(state: RootState, paramValues: Data): void {
@@ -26,7 +26,7 @@ export const mutations = {
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;
     },
-    setErrors(state: RootState, errors: Array<ErrorInfo>): void {
+    setErrors(state: RootState, errors: ErrorInfo[]): void {
         state.errors = errors;
     }
 };

--- a/src/app/static/src/store/state.ts
+++ b/src/app/static/src/store/state.ts
@@ -11,5 +11,5 @@ export interface RootState {
   results: Data | null
   paramValues: Data | null
   fetchingResults: boolean
-  errors: Array<ErrorInfo>
+  errors: ErrorInfo[]
 }

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -4,6 +4,7 @@
       <Parameters class="parameters" v-if="metadata"
                   :paramGroupMetadata="metadata.parameterGroups"
                   :paramValues="paramValues"
+                  :forecastStart="forecastStart"
                   :forecastEnd="forecastEnd"
                   @updateMetadata="setParameterMetadata"
                   @updateValues="updateParameterValues"></Parameters>
@@ -51,6 +52,7 @@ export default defineComponent({
         ]),
         ...mapGetters([
             "chartLayoutData",
+            "forecastStart",
             "forecastEnd"
         ])
     },

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -4,6 +4,7 @@
       <Parameters class="parameters" v-if="metadata"
                   :paramGroupMetadata="metadata.parameterGroups"
                   :paramValues="paramValues"
+                  :forecastEnd="forecastEnd"
                   @updateMetadata="setParameterMetadata"
                   @updateValues="updateParameterValues"></Parameters>
     </div>
@@ -49,7 +50,8 @@ export default defineComponent({
             "fetchingResults"
         ]),
         ...mapGetters([
-            "chartLayoutData"
+            "chartLayoutData",
+            "forecastEnd"
         ])
     },
     methods: {

--- a/src/app/static/tests/unit/components/home.test.ts
+++ b/src/app/static/tests/unit/components/home.test.ts
@@ -45,7 +45,11 @@ describe("Home", () => {
                 results: { value: "results" },
                 paramValues: { value: "paramValue" }
             }),
-            getters
+            getters: {
+                ...getters,
+                forecastStart: () => new Date("2021-01-01"),
+                forecastEnd: () => new Date("2021-06-01")
+            }
         });
 
         const wrapper = shallowMount(Home, { store });
@@ -62,6 +66,8 @@ describe("Home", () => {
             { value: "paramMetadata" }
         ]);
         expect(parameters.props("paramValues")).toStrictEqual({ value: "paramValue" });
+        expect(parameters.props("forecastStart")).toStrictEqual(new Date("2021-01-01"));
+        expect(parameters.props("forecastEnd")).toStrictEqual(new Date("2021-06-01"));
     });
 
     it("does not render Charts or Parameters component if no metadata", () => {

--- a/src/app/static/tests/unit/components/home.test.ts
+++ b/src/app/static/tests/unit/components/home.test.ts
@@ -10,7 +10,7 @@ import Home from "@/views/Home.vue";
 import Charts from "@/components/charts/Charts.vue";
 import Parameters from "@/components/parameters/Parameters.vue";
 import { RootState } from "@/store/state";
-import { getters } from "@/store";
+import { getters } from "@/store/getters";
 import { mockRootState } from "../../mocks";
 
 describe("Home", () => {

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -4,6 +4,7 @@ import Parameters from "@/components/parameters/Parameters.vue";
 import { DynamicForm } from "@reside-ic/vue-dynamic-form";
 import EditParameters from "@/components/parameters/EditParameters.vue";
 import Collapsible from "@/components/Collapsible.vue";
+import Phases from "@/components/parameters/Phases.vue";
 
 describe("Parameters", () => {
     const paramGroupMetadata = [
@@ -28,7 +29,10 @@ describe("Parameters", () => {
         {
             id: "pg2",
             label: "Group 2",
-            type: "rt"
+            type: "rt",
+            config: [
+                { start: "2021-01-01", value: "1" }
+            ]
         },
         {
             id: "pg3",
@@ -57,14 +61,22 @@ describe("Parameters", () => {
         }
     };
 
+    const forecastStart = new Date("2021-01-01");
+    const forecastEnd = new Date("2021-06-01");
+
     function getWrapper() {
-        return shallowMount(Parameters, { propsData: { paramGroupMetadata, paramValues } });
+        return shallowMount(Parameters, { propsData: {
+            paramGroupMetadata,
+            paramValues,
+            forecastStart,
+            forecastEnd
+        } });
     }
 
-    it("renders collapsible dynamicForm parameter groups", () => {
+    it("renders collapsible dynamicForm and phases parameter groups", () => {
         const wrapper = getWrapper();
         const collapsibles = wrapper.findAllComponents(Collapsible);
-        expect(collapsibles.length).toBe(2);
+        expect(collapsibles.length).toBe(3);
 
         expect(collapsibles.at(0).props("initialOpen")).toBe(false);
         expect(collapsibles.at(0).props("heading")).toBe("Group 1");
@@ -73,8 +85,15 @@ describe("Parameters", () => {
         expect(form1.props("formMeta")).toStrictEqual(paramGroupMetadata[0].config);
 
         expect(collapsibles.at(1).props("initialOpen")).toBe(false);
-        expect(collapsibles.at(1).props("heading")).toBe("Group 3");
-        const form2 = collapsibles.at(1).findComponent(DynamicForm);
+        expect(collapsibles.at(1).props("heading")).toBe("Group 2");
+        const phases = collapsibles.at(1).findComponent(Phases);
+        expect(phases.props("forecastStart")).toBe(forecastStart);
+        expect(phases.props("forecastEnd")).toBe(forecastEnd);
+        expect(phases.props("phases")).toStrictEqual(paramGroupMetadata[1].config);
+
+        expect(collapsibles.at(2).props("initialOpen")).toBe(false);
+        expect(collapsibles.at(2).props("heading")).toBe("Group 3");
+        const form2 = collapsibles.at(2).findComponent(DynamicForm);
         expect(form2.props("readonly")).toStrictEqual(true);
         expect(form2.props("formMeta")).toStrictEqual(paramGroupMetadata[2].config);
     });

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -65,12 +65,14 @@ describe("Parameters", () => {
     const forecastEnd = new Date("2021-06-01");
 
     function getWrapper() {
-        return shallowMount(Parameters, { propsData: {
-            paramGroupMetadata,
-            paramValues,
-            forecastStart,
-            forecastEnd
-        } });
+        return shallowMount(Parameters, {
+            propsData: {
+                paramGroupMetadata,
+                paramValues,
+                forecastStart,
+                forecastEnd
+            }
+        });
     }
 
     it("renders collapsible dynamicForm and phases parameter groups", () => {

--- a/src/app/static/tests/unit/components/parameters/phases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/phases.test.ts
@@ -1,4 +1,4 @@
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import Phases from "@/components/parameters/Phases.vue";
 
 describe("Phases", () => {
@@ -7,7 +7,8 @@ describe("Phases", () => {
             { start: "2021-01-01", value: "2" },
             { start: "2021-01-03", value: "8" }
         ];
-        const wrapper = shallowMount(Phases, { propsData: {
+        const wrapper = shallowMount(Phases, {
+            propsData: {
                 phases,
                 forecastStart: new Date("2021-01-01"),
                 forecastEnd: new Date("2021-01-10")
@@ -39,15 +40,16 @@ describe("Phases", () => {
 
     it("renders as expected when first phase starts after forecastStart", () => {
         const phases = [
-          { start: "2021-01-01", value: "1.5" },
-          { start: "2021-01-03", value: "0.5" }
+            { start: "2021-01-01", value: "1.5" },
+            { start: "2021-01-03", value: "0.5" }
         ];
 
-        const wrapper = shallowMount(Phases, { propsData: {
-            phases,
-            forecastStart: new Date("2020-12-31"),
-            forecastEnd: new Date("2021-01-04")
-          }
+        const wrapper = shallowMount(Phases, {
+            propsData: {
+                phases,
+                forecastStart: new Date("2020-12-31"),
+                forecastEnd: new Date("2021-01-04")
+            }
         });
 
         const phaseBlocks = wrapper.findAll(".phase-block-container .phase-block");

--- a/src/app/static/tests/unit/components/parameters/phases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/phases.test.ts
@@ -1,0 +1,73 @@
+import {shallowMount} from "@vue/test-utils";
+import Phases from "@/components/parameters/Phases.vue";
+
+describe("Phases", () => {
+    it("renders as expected when first phase starts on forecastStart", () => {
+        const phases = [
+            { start: "2021-01-01", value: "2" },
+            { start: "2021-01-03", value: "8" }
+        ];
+        const wrapper = shallowMount(Phases, { propsData: {
+                phases,
+                forecastStart: new Date("2021-01-01"),
+                forecastEnd: new Date("2021-01-10")
+            }
+        });
+
+        const phaseBlocks = wrapper.findAll(".phase-block-container .phase-block");
+        expect(phaseBlocks.length).toBe(2);
+        expect(phaseBlocks.at(0).attributes("class")).toBe("phase-block phase-odd");
+        expect(phaseBlocks.at(0).element.style.height).toBe("25.00%");
+        expect(phaseBlocks.at(0).element.style.width).toBe("20.00%");
+        expect(phaseBlocks.at(0).element.style.left).toBe("0.00%");
+
+        expect(phaseBlocks.at(1).attributes("class")).toBe("phase-block phase-even");
+        expect(phaseBlocks.at(1).element.style.height).toBe("100.00%");
+        expect(phaseBlocks.at(1).element.style.width).toBe("80.00%");
+        expect(phaseBlocks.at(1).element.style.left).toBe("20.00%");
+
+        const phaseDescs = wrapper.findAll(".phase-description");
+        expect(phaseDescs.length).toBe(2);
+        expect(phaseDescs.at(0).find(".phase-header").text()).toBe("Phase 1 (2 days)");
+        expect(phaseDescs.at(0).find(".phase-dates").text()).toBe("01/01/21 - 02/01/21");
+        expect(phaseDescs.at(0).find(".phase-rt").text()).toBe("Rt: 2");
+
+        expect(phaseDescs.at(1).find(".phase-header").text()).toBe("Phase 2 (8 days)");
+        expect(phaseDescs.at(1).find(".phase-dates").text()).toBe("03/01/21 - 10/01/21");
+        expect(phaseDescs.at(1).find(".phase-rt").text()).toBe("Rt: 8");
+    });
+
+    it("renders as expected when first phase starts after forecastStart", () => {
+        const phases = [
+          { start: "2021-01-01", value: "1.5" },
+          { start: "2021-01-03", value: "0.5" }
+        ];
+
+        const wrapper = shallowMount(Phases, { propsData: {
+            phases,
+            forecastStart: new Date("2020-12-31"),
+            forecastEnd: new Date("2021-01-04")
+          }
+        });
+
+        const phaseBlocks = wrapper.findAll(".phase-block-container .phase-block");
+        expect(phaseBlocks.length).toBe(2);
+        expect(phaseBlocks.at(0).element.style.height).toBe("100.00%");
+        expect(phaseBlocks.at(0).element.style.width).toBe("40.00%");
+        expect(phaseBlocks.at(0).element.style.left).toBe("20.00%");
+
+        expect(phaseBlocks.at(1).element.style.height).toBe("33.33%");
+        expect(phaseBlocks.at(1).element.style.width).toBe("40.00%");
+        expect(phaseBlocks.at(1).element.style.left).toBe("60.00%");
+
+        const phaseDescs = wrapper.findAll(".phase-description");
+        expect(phaseDescs.length).toBe(2);
+        expect(phaseDescs.at(0).find(".phase-header").text()).toBe("Phase 1 (2 days)");
+        expect(phaseDescs.at(0).find(".phase-dates").text()).toBe("01/01/21 - 02/01/21");
+        expect(phaseDescs.at(0).find(".phase-rt").text()).toBe("Rt: 1.5");
+
+        expect(phaseDescs.at(1).find(".phase-header").text()).toBe("Phase 2 (2 days)");
+        expect(phaseDescs.at(1).find(".phase-dates").text()).toBe("03/01/21 - 04/01/21");
+        expect(phaseDescs.at(1).find(".phase-rt").text()).toBe("Rt: 0.5");
+    });
+});

--- a/src/app/static/tests/unit/store/getters.test.ts
+++ b/src/app/static/tests/unit/store/getters.test.ts
@@ -1,0 +1,18 @@
+import { getters } from "@/store/getters";
+
+describe("getters", () => {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    it("forecastStart returns expected Date", () => {
+        const forecastStart = getters.forecastStart();
+        expect(forecastStart).toEqual(today);
+    });
+
+    it("forecastEnd returns expected Date", () => {
+        const millisValue = today.valueOf() + (1000 * 60 * 60 * 24 * 730);
+        const expected = new Date(millisValue);
+        const forecastEnd = getters.forecastEnd();
+        expect(forecastEnd).toEqual(expected);
+    });
+});


### PR DESCRIPTION
Adds a Phases component which displays "rt" type parameter groups as per the [mockups](https://docs.google.com/presentation/d/1cEwtX94_c3iXJ0uiKe3gM9fFtZKSNzICJE0YAyk5lH0/edit#slide=id.gc9efb13a39_0_312).

This uses new `forecastStart` and `forecastEnd` props in the state. There is [another ticket ](https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2442)to handle counting from the forecast from the last reporting day rather than today. Once this is done, all dates we deal with should be pure dates without time parts - I think the day counting can be a little out at the moment because the jsonata for the default phases uses `$now`.

There's a missing margin between the phases component and the collapsible header above, but I'll sort that when I start putting in the edit controls in the next ticket. 