### PR TITLE
mrc-2446 Update Phase Rt values from Phase Editor

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -4406,6 +4406,11 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "animate.css": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
+      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -13,6 +13,7 @@
     "@reside-ic/vue-dynamic-form": "^0.7.1",
     "@vue/composition-api": "^1.0.0-rc.8",
     "ajv": "^8.2.0",
+    "animate.css": "^4.1.1",
     "axios": "^0.21.1",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -27,15 +27,17 @@
                  @mouseup="mouseUp">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>
               <div class="slider-text">
-                <span class="phase-label font-weight-bold">
-                  Phase {{displayPhases[index].index}}
-                </span>
-                <span class="phase-days">
-                  ({{displayPhases[index].days}} day{{displayPhases[index].days > 1 ? "s" : ""}})
-                </span>
-                <br/>
-                <div class="phase-start">Start: {{displayPhases[index].start}}</div>
-                <div class="phase-end">End: {{displayPhases[index].end}}</div>
+                <div @mousedown.prevent="">
+                  <span class="phase-label font-weight-bold">
+                    Phase {{displayPhases[index].index}}
+                  </span>
+                  <span class="phase-days">
+                    ({{displayPhases[index].days}} day{{displayPhases[index].days > 1 ? "s" : ""}})
+                  </span>
+                  <br/>
+                  <div class="phase-start">Start: {{displayPhases[index].start}}</div>
+                  <div class="phase-end">End: {{displayPhases[index].end}}</div>
+                </div>
                 <div class="phase-rt">Rt:
                   <input
                     :id="`phase-rt-${index}`"

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -43,7 +43,7 @@
                     :min="rtMin"
                     :max="rtMax"
                     :value="sliderValues[index].value.rt"
-                    step=".01"
+                    step="0.01"
                     @change="updateRt(index, $event)"
                     @mousedown.stop="">
                 </div>

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -2,7 +2,7 @@
   <div>
     <modal class="phase-modal" :open="open">
       <h3>Edit {{paramGroup && paramGroup.label}}</h3>
-      <div>
+      <div class="mb-3">
         Click on a Phase to drag it to a new start date.
         <div id="rt-range-text"
              class="d-inline-block"
@@ -53,7 +53,8 @@
                     :value="sliderValues[index].value.rt"
                     step="0.01"
                     @change="updateRt(index, $event)"
-                    @mousedown.stop="bringSliderToFront(index)">
+                    @mousedown.stop=""
+                    @click="bringSliderToFront(index)">
                 </div>
               </div>
             </div>

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -261,10 +261,10 @@ describe("EditPhases", () => {
     });
 
     it("Rt value is unchanged when user clears value", async () => {
-      const wrapper = getWrapper();
-      await inputRtValue(wrapper, 0, "");
+        const wrapper = getWrapper();
+        await inputRtValue(wrapper, 0, "");
 
-      expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0.9");
-      expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0.9);
+        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0.9");
+        expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0.9);
     });
 });

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -55,8 +55,8 @@ describe("EditPhases", () => {
         const wrapper = getWrapper();
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("h3").text()).toBe("Edit Social restrictions");
-        expect(modal.find("p").text()).toContain("Click on a Phase to drag it to a new start date.");
-        expect(modal.find("p").text()).toContain("Rt values must be between 0 and 4.");
+        expect(modal.find(".mb-3").text()).toContain("Click on a Phase to drag it to a new start date.");
+        expect(modal.find("#rt-range-text").text()).toBe("Rt values must be between 0 and 4.");
 
         const rail = modal.find(".phase-editor .phases-container .rail");
 
@@ -188,13 +188,13 @@ describe("EditPhases", () => {
         expect(sliders.at(1).element.style.zIndex).toBe("100");
     });
 
-    it("mousedown on input brings slider to front", async () => {
+    it("click on input brings slider to front", async () => {
         const wrapper = getWrapper();
         const sliders = wrapper.findAll(".slider");
 
         await sliders.at(0).trigger("mousedown", { offsetX: 0 });
 
-        await sliders.at(1).find("input").trigger("mousedown", { offsetX: 0 });
+        await sliders.at(1).find("input").trigger("click", { offsetX: 0 });
         expect(sliders.at(0).element.style.zIndex).toBe("99");
         expect(sliders.at(1).element.style.zIndex).toBe("100");
     });
@@ -262,7 +262,7 @@ describe("EditPhases", () => {
         expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0");
         expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0);
 
-        //shows validation animation
+        // shows validation animation
         const rtRangeText = wrapper.find("#rt-range-text");
         expect(rtRangeText.classes()).toStrictEqual(["d-inline-block", "animate__animated", "animate__headShake"]);
         const input1 = wrapper.findAll(".slider input").at(0);
@@ -270,10 +270,10 @@ describe("EditPhases", () => {
         const input2 = wrapper.findAll(".slider input").at(1);
         expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
         setTimeout(() => {
-          expect(rtRangeText.classes()).toStrictEqual(["d-inline-block"]);
-          expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
-          expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
-          done();
+            expect(rtRangeText.classes()).toStrictEqual(["d-inline-block"]);
+            expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
+            expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
+            done();
         }, 1100);
     });
 
@@ -284,7 +284,7 @@ describe("EditPhases", () => {
         expect((wrapper.find("#phase-rt-1").element as HTMLInputElement).value).toBe("4");
         expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(4);
 
-        //shows validation animation
+        // shows validation animation
         const rtRangeText = wrapper.find("#rt-range-text");
         expect(rtRangeText.classes()).toStrictEqual(["d-inline-block", "animate__animated", "animate__headShake"]);
         const input1 = wrapper.findAll(".slider input").at(0);
@@ -292,10 +292,10 @@ describe("EditPhases", () => {
         const input2 = wrapper.findAll(".slider input").at(1);
         expect(input2.classes()).toStrictEqual(["phase-rt-input", "animate__animated", "animate__headShake"]);
         setTimeout(() => {
-          expect(rtRangeText.classes()).toStrictEqual(["d-inline-block"]);
-          expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
-          expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
-          done();
+            expect(rtRangeText.classes()).toStrictEqual(["d-inline-block"]);
+            expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
+            expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
+            done();
         }, 1100);
     });
 

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -44,10 +44,19 @@ describe("EditPhases", () => {
         await Vue.nextTick();
     }
 
+    async function inputRtValue(wrapper: Wrapper<Vue>, index: number, value: string) {
+        const input = wrapper.find(`#phase-rt-${index}`);
+        input.setValue(value);
+        input.trigger("change");
+        await Vue.nextTick();
+    }
+
     it("renders as expected", () => {
         const wrapper = getWrapper();
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("h3").text()).toBe("Edit Social restrictions");
+        expect(modal.find("p").text()).toContain("Click on a Phase to drag it to a new start date.");
+        expect(modal.find("p").text()).toContain("Rt values must be between 0 and 4.");
 
         const rail = modal.find(".phase-editor .phases-container .rail");
 
@@ -71,7 +80,14 @@ describe("EditPhases", () => {
         expect(slider1.find(".phase-days").text()).toBe("(3 days)");
         expect(slider1.find(".phase-start").text()).toBe("Start: 02/01/21");
         expect(slider1.find(".phase-end").text()).toBe("End: 04/01/21");
-        expect(slider1.find(".phase-rt").text()).toBe("Rt: 0.9");
+        expect(slider1.find(".phase-rt").text()).toBe("Rt:");
+        const rtInput1 = slider1.find("input");
+        expect(rtInput1.attributes("id")).toBe("phase-rt-0");
+        expect(rtInput1.attributes("type")).toBe("number");
+        expect(rtInput1.attributes("min")).toBe("0");
+        expect(rtInput1.attributes("max")).toBe("4");
+        expect(rtInput1.attributes("step")).toBe("0.01");
+        expect((rtInput1.element as HTMLInputElement).value).toBe("0.9");
 
         const slider2 = sliders.at(1);
         expect(slider2.attributes("role")).toBe("slider");
@@ -90,7 +106,14 @@ describe("EditPhases", () => {
         expect(slider2.find(".phase-days").text()).toBe("(6 days)");
         expect(slider2.find(".phase-start").text()).toBe("Start: 05/01/21");
         expect(slider2.find(".phase-end").text()).toBe("End: 10/01/21");
-        expect(slider2.find(".phase-rt").text()).toBe("Rt: 1.5");
+        expect(slider2.find(".phase-rt").text()).toBe("Rt:");
+        const rtInput2 = slider1.find("input");
+        expect(rtInput2.attributes("id")).toBe("phase-rt-0");
+        expect(rtInput2.attributes("type")).toBe("number");
+        expect(rtInput2.attributes("min")).toBe("0");
+        expect(rtInput2.attributes("max")).toBe("4");
+        expect(rtInput2.attributes("step")).toBe("0.01");
+        expect((rtInput2.element as HTMLInputElement).value).toBe("0.9");
 
         expect(modal.find("button.btn-action").text()).toBe("OK");
         expect(modal.find("button.btn-secondary").text()).toBe("Cancel");
@@ -130,11 +153,17 @@ describe("EditPhases", () => {
         await dragSlider(wrapper, 0, 10);
         await dragSlider(wrapper, 1, 20);
 
+        wrapper.find("#phase-rt-0").setValue("1.9");
+        wrapper.find("#phase-rt-0").trigger("change");
+        wrapper.find("#phase-rt-1").setValue("3.99");
+        await inputRtValue(wrapper, 0, "1.9");
+        await inputRtValue(wrapper, 1, "3.99");
+
         wrapper.find("button.btn-action").trigger("click");
         expect(wrapper.emitted("update")?.length).toBe(1);
         expect(wrapper.emitted("update")![0][0]).toStrictEqual([
-            { start: "2021-01-03", value: 0.9 },
-            { start: "2021-01-07", value: 1.5 }
+            { start: "2021-01-03", value: 1.9 },
+            { start: "2021-01-07", value: 3.99 }
         ]);
     });
 
@@ -197,5 +226,45 @@ describe("EditPhases", () => {
         expect(slider.element.style.left).toBe("20%");
         expect(slider.attributes("aria-valuenow")).toBe("2");
         expect(slider.find(".phase-start").text()).toBe("Start: 03/01/21");
+    });
+
+    it("can update Rt value", async () => {
+        const wrapper = getWrapper();
+        await inputRtValue(wrapper, 0, "2.53");
+
+        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("2.53");
+        expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(2.53);
+    });
+
+    it("trims excess decimal places when user enters Rt value", async () => {
+        const wrapper = getWrapper();
+        await inputRtValue(wrapper, 1, "1.3199");
+
+        expect((wrapper.find("#phase-rt-1").element as HTMLInputElement).value).toBe("1.32");
+        expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(1.32);
+    });
+
+    it("sets Rt value to min when user enters value less than min", async () => {
+        const wrapper = getWrapper();
+        await inputRtValue(wrapper, 0, "-0.1");
+
+        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0");
+        expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0);
+    });
+
+    it("sets Rt value to max when user enters value greater than max", async () => {
+        const wrapper = getWrapper();
+        await inputRtValue(wrapper, 1, "5.5555");
+
+        expect((wrapper.find("#phase-rt-1").element as HTMLInputElement).value).toBe("4");
+        expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(4);
+    });
+
+    it("Rt value is unchanged when user clears value", async () => {
+      const wrapper = getWrapper();
+      await inputRtValue(wrapper, 0, "");
+
+      expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0.9");
+      expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0.9);
     });
 });

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -188,6 +188,17 @@ describe("EditPhases", () => {
         expect(sliders.at(1).element.style.zIndex).toBe("100");
     });
 
+    it("mousedown on input brings slider to front", async () => {
+        const wrapper = getWrapper();
+        const sliders = wrapper.findAll(".slider");
+
+        await sliders.at(0).trigger("mousedown", { offsetX: 0 });
+
+        await sliders.at(1).find("input").trigger("mousedown", { offsetX: 0 });
+        expect(sliders.at(0).element.style.zIndex).toBe("99");
+        expect(sliders.at(1).element.style.zIndex).toBe("100");
+    });
+
     it("slider value is limited by forecast start", async () => {
         const wrapper = getWrapper();
         await dragSlider(wrapper, 0, -100);
@@ -244,20 +255,48 @@ describe("EditPhases", () => {
         expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(1.32);
     });
 
-    it("sets Rt value to min when user enters value less than min", async () => {
+    it("sets Rt value to min when user enters value less than min", async (done) => {
         const wrapper = getWrapper();
         await inputRtValue(wrapper, 0, "-0.1");
 
         expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0");
         expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0);
+
+        //shows validation animation
+        const rtRangeText = wrapper.find("#rt-range-text");
+        expect(rtRangeText.classes()).toStrictEqual(["d-inline-block", "animate__animated", "animate__headShake"]);
+        const input1 = wrapper.findAll(".slider input").at(0);
+        expect(input1.classes()).toStrictEqual(["phase-rt-input", "animate__animated", "animate__headShake"]);
+        const input2 = wrapper.findAll(".slider input").at(1);
+        expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
+        setTimeout(() => {
+          expect(rtRangeText.classes()).toStrictEqual(["d-inline-block"]);
+          expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
+          expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
+          done();
+        }, 1100);
     });
 
-    it("sets Rt value to max when user enters value greater than max", async () => {
+    it("sets Rt value to max when user enters value greater than max", async (done) => {
         const wrapper = getWrapper();
         await inputRtValue(wrapper, 1, "5.5555");
 
         expect((wrapper.find("#phase-rt-1").element as HTMLInputElement).value).toBe("4");
         expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(4);
+
+        //shows validation animation
+        const rtRangeText = wrapper.find("#rt-range-text");
+        expect(rtRangeText.classes()).toStrictEqual(["d-inline-block", "animate__animated", "animate__headShake"]);
+        const input1 = wrapper.findAll(".slider input").at(0);
+        expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
+        const input2 = wrapper.findAll(".slider input").at(1);
+        expect(input2.classes()).toStrictEqual(["phase-rt-input", "animate__animated", "animate__headShake"]);
+        setTimeout(() => {
+          expect(rtRangeText.classes()).toStrictEqual(["d-inline-block"]);
+          expect(input1.classes()).toStrictEqual(["phase-rt-input"]);
+          expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
+          done();
+        }, 1100);
     });
 
     it("Rt value is unchanged when user clears value", async () => {


### PR DESCRIPTION
Allows user to update Rt values of Phases. Rt values are constrained by min 0 and max 4, and are only saved with 2 decimal places. 

Uses [this technique](https://michaelnthiessen.com/force-re-render/) (update element key) to ensure the input is correctly re-rendered if the user enters invalid value. This silently updates the value to a valid one - even though there is a note in the dialog header, perhaps there should be more feedback to user that their value was not valid?