### PR TITLE
mrc-2447 User can add a Phase in the editor by clicking on the timeline

### DIFF
--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -55,6 +55,7 @@
                     :value="value.rt"
                     step="0.01"
                     @change="updateRt(index, $event)"
+                    @blur="updateRt(index, $event)"
                     @mousedown.stop=""
                     @click="bringSliderToFront(index)">
                 </div>
@@ -118,13 +119,12 @@ export default defineComponent({
     setup(props: Props, context) {
         const rail: Ref<HTMLElement | null> = ref(null); // ref this element to find its width
 
-        const rtMin = 0;
+        const rtMin = 0.01;
         const rtMax = 4;
         const animateRtValidationIndex: Ref<number | null> = ref(null);
 
         // We need to force re-render of Rt input if user enters invalid value - get vue to do this
         // by updating key of parent
-        //const sliderUpdateKeys = (props.paramGroup.config as Rt[]).map(() => ref(0));
         const sliderUpdateKeys = ref((props.paramGroup.config as Rt[]).map(() => 0));
 
         const railWidth = () => {
@@ -303,7 +303,7 @@ export default defineComponent({
 .phase-modal {
   @media (min-width: 1000px) {
     .modal-dialog-centered {
-      max-width: 900px;
+      max-width: 908px;
     }
   }
 

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -79,7 +79,7 @@ import {
     computed,
     Ref,
     ref,
-    defineComponent, watch
+    defineComponent
 } from "@vue/composition-api";
 import Modal from "@/components/Modal.vue";
 import { ParameterGroupMetadata, Rt } from "@/types";
@@ -130,13 +130,14 @@ export default defineComponent({
             return rail.value ? (rail.value as HTMLElement).clientWidth : 0;
         };
 
-        const sliderValues: Ref<SliderValue[]> = ref((props.paramGroup.config as Rt[]).map((phase) => {
-            return {
-                daysFromStart: daysBetween(props.forecastStart, dayjs(phase.start)),
-                rt: phase.value,
-                zIndex: 99
-            };
-        }));
+        const sliderValues: Ref<SliderValue[]> = ref((props.paramGroup.config as Rt[])
+            .map((phase) => {
+                return {
+                    daysFromStart: daysBetween(props.forecastStart, dayjs(phase.start)),
+                    rt: phase.value,
+                    zIndex: 99
+                };
+            }));
 
         // Phases computed from the slider values
         const phases: Ref<Rt[]> = computed(() => {
@@ -176,6 +177,7 @@ export default defineComponent({
 
         const bringSliderToFront = (index: number) => {
             sliderValues.value.forEach((sv: SliderValue, arrIdx: number) => {
+                // eslint-disable-next-line no-param-reassign
                 sv.zIndex = (arrIdx === index) ? 100 : 99;
             });
         };

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -33,7 +33,7 @@
                  @click.stop="">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>
               <div class="slider-text">
-                <div @mousedown.prevent="">
+                <div class="disable-select">
                   <span class="phase-label font-weight-bold">
                     Phase {{displayPhases[index].index}}
                   </span>
@@ -52,10 +52,9 @@
                     type="number"
                     :min="rtMin"
                     :max="rtMax"
-                    :value="value.rt"
+                    v-model="value.rt"
                     step="0.01"
                     @change="updateRt(index, $event)"
-                    @blur="updateRt(index, $event)"
                     @mousedown.stop=""
                     @click="bringSliderToFront(index)">
                 </div>
@@ -337,6 +336,14 @@ export default defineComponent({
       .slider-text {
         position: absolute;
         padding: 0.5rem;
+
+        .disable-select {
+          user-select: none; /* supported by Chrome and Opera */
+          -webkit-user-select: none; /* Safari */
+          -khtml-user-select: none; /* Konqueror HTML */
+          -moz-user-select: none; /* Firefox */
+          -ms-user-select: none; /* Internet Explorer/Edge */
+        }
 
         .phase-rt-input {
           width: 4rem;

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -12,7 +12,8 @@
       </div>
       <div class="phase-editor" @mouseup="mouseUp">
         <div class="phases-container">
-          <div ref="rail" class="rail">
+          <div ref="rail" class="rail"
+               @click="addPhase">
             <div v-for="(value, index) in sliderValues"
                  :id="`slider-${index}-${sliderUpdateKeys[index].value}`"
                  :key="index"
@@ -28,7 +29,8 @@
                  :aria-label="`Phase ${displayPhases[index].index}`"
                  @mousemove="mouseMove(index, $event)"
                  @mousedown="mouseDown(index, $event)"
-                 @mouseup="mouseUp">
+                 @mouseup="mouseUp"
+                 @click.stop="">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>
               <div class="slider-text">
                 <div @mousedown.prevent="">
@@ -186,11 +188,15 @@ export default defineComponent({
             bringSliderToFront(index);
         };
 
+        const sliderValueAsDays = (sliderValue: number) => {
+            const valueAsRangeFraction = sliderValue / railWidth();
+            return totalDays * valueAsRangeFraction;
+        };
+
         const mouseMove = (index: number, event: MouseEvent) => {
             if (movingSlider.value === index && moveStartOffset.value !== null) {
                 const offsetDiff = event.offsetX - moveStartOffset.value;
-                const diffAsRangeFraction = offsetDiff / railWidth();
-                const valueDiff = totalDays * diffAsRangeFraction;
+                const valueDiff = sliderValueAsDays(offsetDiff);
                 const oldValue = sliderValues[index].value.daysFromStart;
                 const newValue = limitSliderValue(index, oldValue + valueDiff);
                 sliderValues[index].value.daysFromStart = newValue;
@@ -239,6 +245,11 @@ export default defineComponent({
             sliderUpdateKeys[index].value += 1;
         };
 
+        const addPhase = (event: MouseEvent) => {
+            const days = sliderValueAsDays(event.offsetX);
+            alert(`adding phase with offset ${JSON.stringify(event.offsetX)}, days from start: ${days}`);
+        };
+
         const cancel = () => {
             context.emit("cancel");
         };
@@ -266,6 +277,7 @@ export default defineComponent({
             mouseDown,
             mouseUp,
             updateRt,
+            addPhase,
             cancel,
             updatePhases,
             phaseClassFromIndex

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -3,7 +3,8 @@
     <modal class="phase-modal" :open="open">
       <h3>Edit {{paramGroup && paramGroup.label}}</h3>
       <div class="mb-3">
-        Click on a Phase to drag it to a new start date. Click above the timeline to add a new Phase.
+        Click on a Phase to drag it to a new start date.
+        Click above the timeline to add a new Phase.
         <div id="rt-range-text"
              class="d-inline-block"
              :class="rtTextValidationClass()">

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -3,7 +3,7 @@
     <modal class="phase-modal" :open="open">
       <h3>Edit {{paramGroup && paramGroup.label}}</h3>
       <div class="mb-3">
-        Click on a Phase to drag it to a new start date. Click on timeline to add a new Phase.
+        Click on a Phase to drag it to a new start date. Click above the timeline to add a new Phase.
         <div id="rt-range-text"
              class="d-inline-block"
              :class="rtTextValidationClass()">

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -33,7 +33,7 @@
                  @click.stop="">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>
               <div class="slider-text">
-                <div class="disable-select">
+                <div class="phase-dates disable-select">
                   <span class="phase-label font-weight-bold">
                     Phase {{displayPhases[index].index}}
                   </span>
@@ -79,7 +79,7 @@ import {
     computed,
     Ref,
     ref,
-    defineComponent
+    defineComponent, watch
 } from "@vue/composition-api";
 import Modal from "@/components/Modal.vue";
 import { ParameterGroupMetadata, Rt } from "@/types";
@@ -229,8 +229,11 @@ export default defineComponent({
 
         const updateRt = (index: number, event: Event) => {
             const target = event.target as HTMLInputElement;
-            if (target.value !== "") {
-                let value = Math.round(parseFloat(target.value) * 100) / 100;
+            let value = parseFloat(target.value);
+            if (Number.isNaN(value)) {
+                value = 1.0;
+            } else {
+                value = Math.round(value * 100) / 100;
                 if (value < rtMin) {
                     value = rtMin;
                     showRtValidationAnimation(index);
@@ -239,8 +242,8 @@ export default defineComponent({
                     value = rtMax;
                     showRtValidationAnimation(index);
                 }
-                sliderValues.value[index].rt = value;
             }
+            sliderValues.value[index].rt = value;
             sliderUpdateKeys.value[index] += 1;
         };
 

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -29,7 +29,7 @@ describe("EditPhases", () => {
     function setRailWidth(wrapper: Wrapper<Vue>) {
         const railEl = wrapper.vm.$refs.rail as HTMLDivElement;
         jest.spyOn(railEl, "clientWidth", "get")
-          .mockImplementation(() => 1000);
+            .mockImplementation(() => 1000);
     }
 
     async function dragSlider(wrapper: Wrapper<Vue>, sliderIdx: number, dragAsPercent: number) {
@@ -60,7 +60,8 @@ describe("EditPhases", () => {
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("h3").text()).toBe("Edit Social restrictions");
         expect(modal.find(".mb-3").text()).toContain(
-          "Click on a Phase to drag it to a new start date. Click on timeline to add a new Phase.");
+            "Click on a Phase to drag it to a new start date. Click on timeline to add a new Phase."
+        );
         expect(modal.find("#rt-range-text").text()).toBe("Rt values must be between 0.01 and 4.");
 
         const rail = modal.find(".phase-editor .phases-container .rail");
@@ -309,9 +310,9 @@ describe("EditPhases", () => {
     it("clicking on timeline adds a new first phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);
-        await wrapper.find(".rail").trigger("click", {offsetX: 0});
+        await wrapper.find(".rail").trigger("click", { offsetX: 0 });
 
-        const sliderValues = wrapper.vm.$data.sliderValues;
+        const { sliderValues } = wrapper.vm.$data;
         expect(sliderValues.length).toBe(3);
         expect(sliderValues[0].daysFromStart).toBe(0);
         expect(sliderValues[0].rt).toBe(1);
@@ -348,9 +349,9 @@ describe("EditPhases", () => {
     it("clicking on timeline adds a new last phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);
-        await wrapper.find(".rail").trigger("click", {offsetX: 600});
+        await wrapper.find(".rail").trigger("click", { offsetX: 600 });
 
-        const sliderValues = wrapper.vm.$data.sliderValues;
+        const { sliderValues } = wrapper.vm.$data;
         expect(sliderValues.length).toBe(3);
         expect(sliderValues[2].daysFromStart).toBe(6);
         expect(sliderValues[2].rt).toBe(1);
@@ -387,9 +388,9 @@ describe("EditPhases", () => {
     it("clicking on timeline adds a new intermediate phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);
-        await wrapper.find(".rail").trigger("click", {offsetX: 200});
+        await wrapper.find(".rail").trigger("click", { offsetX: 200 });
 
-        const sliderValues = wrapper.vm.$data.sliderValues;
+        const { sliderValues } = wrapper.vm.$data;
         expect(sliderValues.length).toBe(3);
         expect(sliderValues[1].daysFromStart).toBe(2);
         expect(sliderValues[1].rt).toBe(1);

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -60,7 +60,7 @@ describe("EditPhases", () => {
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("h3").text()).toBe("Edit Social restrictions");
         expect(modal.find(".mb-3").text()).toContain(
-            "Click on a Phase to drag it to a new start date. Click on timeline to add a new Phase."
+            "Click on a Phase to drag it to a new start date. Click above the timeline to add a new Phase."
         );
         expect(modal.find("#rt-range-text").text()).toBe("Rt values must be between 0.01 and 4.");
 

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -307,6 +307,14 @@ describe("EditPhases", () => {
         }, 1100);
     });
 
+    it("Rt value defaults to 1 when user clears value", async () => {
+        const wrapper = getWrapper();
+        await inputRtValue(wrapper, 0, "");
+
+        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("1");
+        expect(wrapper.vm.$data.sliderValues[0].rt).toBe(1);
+    });
+
     it("clicking on timeline adds a new first phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -26,11 +26,15 @@ describe("EditPhases", () => {
         return mount(EditPhases, { propsData });
     }
 
-    async function dragSlider(wrapper: Wrapper<Vue>, sliderIdx: number, dragAsPercent: number) {
-        // set rail element mock width before mousemoves so offset calculations will work
+    function setRailWidth(wrapper: Wrapper<Vue>) {
         const railEl = wrapper.vm.$refs.rail as HTMLDivElement;
         jest.spyOn(railEl, "clientWidth", "get")
-            .mockImplementation(() => 1000);
+          .mockImplementation(() => 1000);
+    }
+
+    async function dragSlider(wrapper: Wrapper<Vue>, sliderIdx: number, dragAsPercent: number) {
+        // set rail element mock width before mousemoves so offset calculations will work
+        setRailWidth(wrapper);
 
         const slider = wrapper.findAll(".slider").at(sliderIdx);
 
@@ -107,13 +111,13 @@ describe("EditPhases", () => {
         expect(slider2.find(".phase-start").text()).toBe("Start: 05/01/21");
         expect(slider2.find(".phase-end").text()).toBe("End: 10/01/21");
         expect(slider2.find(".phase-rt").text()).toBe("Rt:");
-        const rtInput2 = slider1.find("input");
-        expect(rtInput2.attributes("id")).toBe("phase-rt-0");
+        const rtInput2 = slider2.find("input");
+        expect(rtInput2.attributes("id")).toBe("phase-rt-1");
         expect(rtInput2.attributes("type")).toBe("number");
         expect(rtInput2.attributes("min")).toBe("0");
         expect(rtInput2.attributes("max")).toBe("4");
         expect(rtInput2.attributes("step")).toBe("0.01");
-        expect((rtInput2.element as HTMLInputElement).value).toBe("0.9");
+        expect((rtInput2.element as HTMLInputElement).value).toBe("1.5");
 
         expect(modal.find("button.btn-action").text()).toBe("OK");
         expect(modal.find("button.btn-secondary").text()).toBe("Cancel");
@@ -305,5 +309,87 @@ describe("EditPhases", () => {
 
         expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0.9");
         expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0.9);
+    });
+
+    it("clicking on timeline adds a new first phase", async () => {
+        const wrapper = getWrapper();
+        setRailWidth(wrapper);
+        await wrapper.find(".rail").trigger("click", {offsetX: 0});
+
+        const sliderValues = wrapper.vm.$data.sliderValues;
+        expect(sliderValues.length).toBe(3);
+        expect(sliderValues[0].daysFromStart).toBe(0);
+        expect(sliderValues[0].rt).toBe(1);
+        expect(sliderValues[0].zIndex).toBe(99);
+
+        const sliders = wrapper.findAll(".slider");
+        expect(sliders.length).toBe(3);
+        const slider1 = sliders.at(0);
+        expect(slider1.element.style.left).toBe("0%");
+        expect(slider1.element.style.zIndex).toBe("99");
+        expect((slider1.find("input").element as HTMLInputElement).value).toBe("1");
+        const slider2 = sliders.at(1);
+        expect(slider2.element.style.left).toBe("10%");
+        expect(slider2.element.style.zIndex).toBe("99");
+        expect((slider2.find("input").element as HTMLInputElement).value).toBe("0.9");
+        const slider3 = sliders.at(2);
+        expect(slider3.element.style.left).toBe("40%");
+        expect(slider3.element.style.zIndex).toBe("99");
+        expect((slider3.find("input").element as HTMLInputElement).value).toBe("1.5");
+    });
+
+    it("clicking on timeline adds a new last phase", async () => {
+        const wrapper = getWrapper();
+        setRailWidth(wrapper);
+        await wrapper.find(".rail").trigger("click", {offsetX: 600});
+
+        const sliderValues = wrapper.vm.$data.sliderValues;
+        expect(sliderValues.length).toBe(3);
+        expect(sliderValues[2].daysFromStart).toBe(6);
+        expect(sliderValues[2].rt).toBe(1);
+        expect(sliderValues[2].zIndex).toBe(99);
+
+        const sliders = wrapper.findAll(".slider");
+        expect(sliders.length).toBe(3);
+        const slider1 = sliders.at(0);
+        expect(slider1.element.style.left).toBe("10%");
+        expect(slider1.element.style.zIndex).toBe("99");
+        expect((slider1.find("input").element as HTMLInputElement).value).toBe("0.9");
+        const slider2 = sliders.at(1);
+        expect(slider2.element.style.left).toBe("40%");
+        expect(slider2.element.style.zIndex).toBe("99");
+        expect((slider2.find("input").element as HTMLInputElement).value).toBe("1.5");
+        const slider3 = sliders.at(2);
+        expect(slider3.element.style.left).toBe("60%");
+        expect(slider3.element.style.zIndex).toBe("99");
+        expect((slider3.find("input").element as HTMLInputElement).value).toBe("1");
+    });
+
+    it("clicking on timeline adds a new intermediate phase", async () => {
+        const wrapper = getWrapper();
+        setRailWidth(wrapper);
+        await wrapper.find(".rail").trigger("click", {offsetX: 200});
+
+        const sliderValues = wrapper.vm.$data.sliderValues;
+        expect(sliderValues.length).toBe(3);
+        expect(sliderValues[1].daysFromStart).toBe(2);
+        expect(sliderValues[1].rt).toBe(1);
+        expect(sliderValues[1].zIndex).toBe(99);
+
+        const sliders = wrapper.findAll(".slider");
+        expect(sliders.length).toBe(3);
+        const slider1 = sliders.at(0);
+        expect(slider1.element.style.left).toBe("10%");
+        expect(slider1.element.style.zIndex).toBe("99");
+        expect((slider1.find("input").element as HTMLInputElement).value).toBe("0.9");
+        const slider2 = sliders.at(1);
+        expect(slider2.element.style.left).toBe("20%");
+        expect(slider2.element.style.zIndex).toBe("99");
+        expect((slider2.find("input").element as HTMLInputElement).value).toBe("1");
+        const slider3 = sliders.at(2);
+        expect(slider3.element.style.left).toBe("40%");
+        expect(slider3.element.style.zIndex).toBe("99");
+        expect((slider3.find("input").element as HTMLInputElement).value).toBe("1.5");
+        //TODO: check date labels for all phases
     });
 });

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -59,8 +59,9 @@ describe("EditPhases", () => {
         const wrapper = getWrapper();
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("h3").text()).toBe("Edit Social restrictions");
-        expect(modal.find(".mb-3").text()).toContain("Click on a Phase to drag it to a new start date.");
-        expect(modal.find("#rt-range-text").text()).toBe("Rt values must be between 0 and 4.");
+        expect(modal.find(".mb-3").text()).toContain(
+          "Click on a Phase to drag it to a new start date. Click on timeline to add a new Phase.");
+        expect(modal.find("#rt-range-text").text()).toBe("Rt values must be between 0.01 and 4.");
 
         const rail = modal.find(".phase-editor .phases-container .rail");
 
@@ -80,6 +81,7 @@ describe("EditPhases", () => {
         expect(slider1.attributes("aria-label")).toBe("Phase 1");
 
         expect(slider1.find(".slider-spike").attributes("class")).toBe("slider-spike phase-odd");
+        expect(slider1.find(".phase-dates").classes()).toContain("disable-select");
         expect(slider1.find(".phase-label").text()).toBe("Phase 1");
         expect(slider1.find(".phase-days").text()).toBe("(3 days)");
         expect(slider1.find(".phase-start").text()).toBe("Start: 02/01/21");
@@ -88,7 +90,7 @@ describe("EditPhases", () => {
         const rtInput1 = slider1.find("input");
         expect(rtInput1.attributes("id")).toBe("phase-rt-0");
         expect(rtInput1.attributes("type")).toBe("number");
-        expect(rtInput1.attributes("min")).toBe("0");
+        expect(rtInput1.attributes("min")).toBe("0.01");
         expect(rtInput1.attributes("max")).toBe("4");
         expect(rtInput1.attributes("step")).toBe("0.01");
         expect((rtInput1.element as HTMLInputElement).value).toBe("0.9");
@@ -106,6 +108,7 @@ describe("EditPhases", () => {
         expect(slider2.attributes("aria-label")).toBe("Phase 2");
 
         expect(slider2.find(".slider-spike").attributes("class")).toBe("slider-spike phase-even");
+        expect(slider2.find(".phase-dates").classes()).toContain("disable-select");
         expect(slider2.find(".phase-label").text()).toBe("Phase 2");
         expect(slider2.find(".phase-days").text()).toBe("(6 days)");
         expect(slider2.find(".phase-start").text()).toBe("Start: 05/01/21");
@@ -114,7 +117,7 @@ describe("EditPhases", () => {
         const rtInput2 = slider2.find("input");
         expect(rtInput2.attributes("id")).toBe("phase-rt-1");
         expect(rtInput2.attributes("type")).toBe("number");
-        expect(rtInput2.attributes("min")).toBe("0");
+        expect(rtInput2.attributes("min")).toBe("0.01");
         expect(rtInput2.attributes("max")).toBe("4");
         expect(rtInput2.attributes("step")).toBe("0.01");
         expect((rtInput2.element as HTMLInputElement).value).toBe("1.5");
@@ -248,7 +251,7 @@ describe("EditPhases", () => {
         await inputRtValue(wrapper, 0, "2.53");
 
         expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("2.53");
-        expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(2.53);
+        expect(wrapper.vm.$data.sliderValues[0].rt).toBe(2.53);
     });
 
     it("trims excess decimal places when user enters Rt value", async () => {
@@ -256,15 +259,15 @@ describe("EditPhases", () => {
         await inputRtValue(wrapper, 1, "1.3199");
 
         expect((wrapper.find("#phase-rt-1").element as HTMLInputElement).value).toBe("1.32");
-        expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(1.32);
+        expect(wrapper.vm.$data.sliderValues[1].rt).toBe(1.32);
     });
 
     it("sets Rt value to min when user enters value less than min", async (done) => {
         const wrapper = getWrapper();
         await inputRtValue(wrapper, 0, "-0.1");
 
-        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0");
-        expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0);
+        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0.01");
+        expect(wrapper.vm.$data.sliderValues[0].rt).toBe(0.01);
 
         // shows validation animation
         const rtRangeText = wrapper.find("#rt-range-text");
@@ -286,7 +289,7 @@ describe("EditPhases", () => {
         await inputRtValue(wrapper, 1, "5.5555");
 
         expect((wrapper.find("#phase-rt-1").element as HTMLInputElement).value).toBe("4");
-        expect(wrapper.vm.$data.sliderValues[1].value.rt).toBe(4);
+        expect(wrapper.vm.$data.sliderValues[1].rt).toBe(4);
 
         // shows validation animation
         const rtRangeText = wrapper.find("#rt-range-text");
@@ -301,14 +304,6 @@ describe("EditPhases", () => {
             expect(input2.classes()).toStrictEqual(["phase-rt-input"]);
             done();
         }, 1100);
-    });
-
-    it("Rt value is unchanged when user clears value", async () => {
-        const wrapper = getWrapper();
-        await inputRtValue(wrapper, 0, "");
-
-        expect((wrapper.find("#phase-rt-0").element as HTMLInputElement).value).toBe("0.9");
-        expect(wrapper.vm.$data.sliderValues[0].value.rt).toBe(0.9);
     });
 
     it("clicking on timeline adds a new first phase", async () => {
@@ -327,14 +322,26 @@ describe("EditPhases", () => {
         const slider1 = sliders.at(0);
         expect(slider1.element.style.left).toBe("0%");
         expect(slider1.element.style.zIndex).toBe("99");
+        expect(slider1.find(".phase-label").text()).toBe("Phase 1");
+        expect(slider1.find(".phase-days").text()).toBe("(1 day)");
+        expect(slider1.find(".phase-start").text()).toBe("Start: 01/01/21");
+        expect(slider1.find(".phase-end").text()).toBe("End: 01/01/21");
         expect((slider1.find("input").element as HTMLInputElement).value).toBe("1");
         const slider2 = sliders.at(1);
         expect(slider2.element.style.left).toBe("10%");
         expect(slider2.element.style.zIndex).toBe("99");
+        expect(slider2.find(".phase-label").text()).toBe("Phase 2");
+        expect(slider2.find(".phase-days").text()).toBe("(3 days)");
+        expect(slider2.find(".phase-start").text()).toBe("Start: 02/01/21");
+        expect(slider2.find(".phase-end").text()).toBe("End: 04/01/21");
         expect((slider2.find("input").element as HTMLInputElement).value).toBe("0.9");
         const slider3 = sliders.at(2);
         expect(slider3.element.style.left).toBe("40%");
         expect(slider3.element.style.zIndex).toBe("99");
+        expect(slider3.find(".phase-label").text()).toBe("Phase 3");
+        expect(slider3.find(".phase-days").text()).toBe("(6 days)");
+        expect(slider3.find(".phase-start").text()).toBe("Start: 05/01/21");
+        expect(slider3.find(".phase-end").text()).toBe("End: 10/01/21");
         expect((slider3.find("input").element as HTMLInputElement).value).toBe("1.5");
     });
 
@@ -354,14 +361,26 @@ describe("EditPhases", () => {
         const slider1 = sliders.at(0);
         expect(slider1.element.style.left).toBe("10%");
         expect(slider1.element.style.zIndex).toBe("99");
+        expect(slider1.find(".phase-label").text()).toBe("Phase 1");
+        expect(slider1.find(".phase-days").text()).toBe("(3 days)");
+        expect(slider1.find(".phase-start").text()).toBe("Start: 02/01/21");
+        expect(slider1.find(".phase-end").text()).toBe("End: 04/01/21");
         expect((slider1.find("input").element as HTMLInputElement).value).toBe("0.9");
         const slider2 = sliders.at(1);
         expect(slider2.element.style.left).toBe("40%");
         expect(slider2.element.style.zIndex).toBe("99");
+        expect(slider2.find(".phase-label").text()).toBe("Phase 2");
+        expect(slider2.find(".phase-days").text()).toBe("(2 days)");
+        expect(slider2.find(".phase-start").text()).toBe("Start: 05/01/21");
+        expect(slider2.find(".phase-end").text()).toBe("End: 06/01/21");
         expect((slider2.find("input").element as HTMLInputElement).value).toBe("1.5");
         const slider3 = sliders.at(2);
         expect(slider3.element.style.left).toBe("60%");
         expect(slider3.element.style.zIndex).toBe("99");
+        expect(slider3.find(".phase-label").text()).toBe("Phase 3");
+        expect(slider3.find(".phase-days").text()).toBe("(4 days)");
+        expect(slider3.find(".phase-start").text()).toBe("Start: 07/01/21");
+        expect(slider3.find(".phase-end").text()).toBe("End: 10/01/21");
         expect((slider3.find("input").element as HTMLInputElement).value).toBe("1");
     });
 
@@ -381,15 +400,26 @@ describe("EditPhases", () => {
         const slider1 = sliders.at(0);
         expect(slider1.element.style.left).toBe("10%");
         expect(slider1.element.style.zIndex).toBe("99");
+        expect(slider1.find(".phase-label").text()).toBe("Phase 1");
+        expect(slider1.find(".phase-days").text()).toBe("(1 day)");
+        expect(slider1.find(".phase-start").text()).toBe("Start: 02/01/21");
+        expect(slider1.find(".phase-end").text()).toBe("End: 02/01/21");
         expect((slider1.find("input").element as HTMLInputElement).value).toBe("0.9");
         const slider2 = sliders.at(1);
         expect(slider2.element.style.left).toBe("20%");
         expect(slider2.element.style.zIndex).toBe("99");
+        expect(slider2.find(".phase-label").text()).toBe("Phase 2");
+        expect(slider2.find(".phase-days").text()).toBe("(2 days)");
+        expect(slider2.find(".phase-start").text()).toBe("Start: 03/01/21");
+        expect(slider2.find(".phase-end").text()).toBe("End: 04/01/21");
         expect((slider2.find("input").element as HTMLInputElement).value).toBe("1");
         const slider3 = sliders.at(2);
         expect(slider3.element.style.left).toBe("40%");
         expect(slider3.element.style.zIndex).toBe("99");
+        expect(slider3.find(".phase-label").text()).toBe("Phase 3");
+        expect(slider3.find(".phase-days").text()).toBe("(6 days)");
+        expect(slider3.find(".phase-start").text()).toBe("Start: 05/01/21");
+        expect(slider3.find(".phase-end").text()).toBe("End: 10/01/21");
         expect((slider3.find("input").element as HTMLInputElement).value).toBe("1.5");
-        //TODO: check date labels for all phases
     });
 });

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -60,7 +60,10 @@ describe("EditPhases", () => {
         const modal = wrapper.findComponent(Modal);
         expect(modal.find("h3").text()).toBe("Edit Social restrictions");
         expect(modal.find(".mb-3").text()).toContain(
-            "Click on a Phase to drag it to a new start date. Click above the timeline to add a new Phase."
+            "Click on a Phase to drag it to a new start date."
+        );
+        expect(modal.find(".mb-3").text()).toContain(
+            "Click above the timeline to add a new Phase."
         );
         expect(modal.find("#rt-range-text").text()).toBe("Rt values must be between 0.01 and 4.");
 


### PR DESCRIPTION
The user can click on the timeline anywhere outside an existing phase to create a new phase at that point in time. This meant changing the computed `sliderValues` property which was previously a `Ref<SliderValue>[]` but now needs to be a `Ref<SliderValue[]>` since the array itself has a variable size. 

Deleting phases to follow in a separate ticket.

Also fixes a couple of other small issues:
- Makes the minimum Rt 0.01 rather than 0 (the backend actually fails with an Rt of 0)
- Fixes bug where blurring an Rt input by clicking on the text part of another phase failed to update the value. This was done by replacing the previous solution to prevent selection of text in the Phase sliders when clicking on them (`@mousedown.prevent` on the text div) with CSS to prevent selection..
- ..this still left another bug where the `change` event on the input was not firing if clicking on another phase was used to try to commit the value the first time an Rt value was changed on Editor load. I thought this might be because of the `:value` vue binding getting in the way and resetting the input value, and sure enough, changing this to `v-model` fixed the issue (though I'm not sure why it only happened for the first change). We still want to invoke the `updateRt` method on `change` to do the validation, rounding and resetting of out of bounds values, and `v-model` does not interfere with that.
- ..and this change means that it's now harder to default to reverting to previous value if user clears the field, so instead it's defaulting to 1, the same default value as for a new phase