### PR TITLE
mrc-2546 Add country drop-down, fetch results  when country changes

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -2489,6 +2489,15 @@
         "source-map": "^0.6.1"
       }
     },
+    "@types/vue-select": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@types/vue-select/-/vue-select-3.11.2.tgz",
+      "integrity": "sha512-9+aQfKFOQ1K9rLOVdcRNKmW12YJ+tFOvCddDyNLC7CtdIqUMmPh0N3/DtKt4LL6bxiz30tgko/BlEN5SkKVSlA==",
+      "dev": true,
+      "requires": {
+        "vue": "^2.0.0"
+      }
+    },
     "@types/webpack": {
       "version": "4.41.27",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
@@ -21402,6 +21411,11 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.1.tgz",
       "integrity": "sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw=="
+    },
+    "vue-select": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.12.2.tgz",
+      "integrity": "sha512-KWIXQ50pC+B1wpBmaUXwuHm8yevPIL8YsZin9Hi2qCdK7C0KMbztRk6adgpIJ99bqaiccrGFQIPuXsuUNeegPw=="
     },
     "vue-style-loader": {
       "version": "4.1.3",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -23,12 +23,14 @@
     "vue": "^2.6.12",
     "vue-feather-icons": "^5.1.0",
     "vue-router": "^3.1.6",
+    "vue-select": "^3.12.2",
     "vuex": "^3.6.2"
   },
   "devDependencies": {
     "@types/ajv": "^1.0.0",
     "@types/jest": "^24.0.19",
     "@types/plotly.js": "^1.54.10",
+    "@types/vue-select": "^3.11.2",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/src/app/static/src/App.vue
+++ b/src/app/static/src/App.vue
@@ -27,6 +27,7 @@
 <style lang="scss">
 @import '../node_modules/bootstrap/scss/bootstrap.scss';
 @import '../node_modules/bootstrap-vue/src/index.scss';
+@import '../node_modules/vue-select/src/scss/vue-select.scss';
 @import 'assets/custom.scss';
 
 body {

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -1,9 +1,12 @@
 $theme-blue: #003e74;
 
+h3 {
+  font-size: 1.3rem;
+}
+
 .parameters {
   .collapsible {
     h3 {
-      font-size: 1.3rem;
       margin-bottom: 0;
 
       svg { //collapse chevrons

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -1,6 +1,6 @@
 $theme-blue: #003e74;
 
-h3 {
+h3, .h3 {
   font-size: 1.3rem;
 }
 

--- a/src/app/static/src/assets/custom.scss
+++ b/src/app/static/src/assets/custom.scss
@@ -99,4 +99,9 @@ h3, .h3 {
   padding: 1rem;
 }
 
+// v-select override
+.vs__dropdown-toggle {
+  background-color: white;
+}
+
 

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -3,7 +3,7 @@
     <div id="countries" class="mb-3">
       <h3>Country</h3>
       <select id="select-country" v-model="selectedCountry" class="form-control">
-        <option v-for="country in countries"
+        <option v-for="country in sortedCountries"
                 :key="country.code"
                 :value="country.code">{{country.name}}</option>
       </select>
@@ -113,6 +113,12 @@ export default defineComponent({
             }
         });
 
+        const sortedCountries = computed(() => {
+            return [...props.countries]
+                .filter((country: Country) => country.public)
+                .sort((a: Country, b: Country) => (a.name > b.name ? 1 : -1));
+        });
+
         function editParameters(paramGroupId: string) {
             editParamGroupId.value = paramGroupId;
             paramsModalOpen.value = true;
@@ -169,6 +175,7 @@ export default defineComponent({
 
         return {
             selectedCountry,
+            sortedCountries,
             paramsModalOpen,
             phasesModalOpen,
             editParamGroupId,

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div id="countries" class="mb-3">
-      <h3>Country</h3>
+      <label for="select-country" class="h3">Country</label>
       <select id="select-country" v-model="selectedCountry" class="form-control">
         <option v-for="country in sortedCountries"
                 :key="country.code"

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -2,11 +2,12 @@
   <div>
     <div id="countries" class="mb-3">
       <label for="select-country" class="h3">Country</label>
-      <select id="select-country" v-model="selectedCountry" class="form-control">
-        <option v-for="country in sortedCountries"
-                :key="country.code"
-                :value="country.code">{{country.name}}</option>
-      </select>
+      <v-select input-id="select-country"
+                v-model="selectedCountry"
+                :options="sortedCountries"
+                label="name"
+                :clearable="false">
+      </v-select>
     </div>
     <div v-for="paramGroup in paramGroupMetadata" :key="paramGroup.id">
       <div>
@@ -55,6 +56,7 @@
 </template>
 
 <script lang="ts">
+import vSelect from "vue-select";
 import { computed, defineComponent, ref } from "@vue/composition-api";
 import {
     DynamicForm,
@@ -86,7 +88,8 @@ export default defineComponent({
         EditParameters,
         EditPhases,
         Collapsible,
-        Phases
+        Phases,
+        vSelect
     },
     props: {
         paramGroupMetadata: Array,
@@ -106,10 +109,11 @@ export default defineComponent({
 
         const selectedCountry = computed({
             get: () => {
-                return props.paramValues.region as string;
+                return props.countries
+                    .find((c:Country) => c.code === props.paramValues.region as string)!;
             },
-            set: (value: string) => {
-                context.emit("updateCountry", value);
+            set: (value: Country) => {
+                context.emit("updateCountry", value.code);
             }
         });
 

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -3,7 +3,9 @@
     <div id="countries" class="mb-3">
       <h3>Country</h3>
       <select id="select-country" v-model="selectedCountry" class="form-control">
-        <option v-for="country in countries" :value="country.code">{{country.name}}</option>
+        <option v-for="country in countries"
+                :key="country.code"
+                :value="country.code">{{country.name}}</option>
       </select>
     </div>
     <div v-for="paramGroup in paramGroupMetadata" :key="paramGroup.id">
@@ -58,7 +60,12 @@ import {
     DynamicForm,
     DynamicFormData
 } from "@reside-ic/vue-dynamic-form";
-import {Country, Data, ParameterGroupMetadata, Rt} from "@/types";
+import {
+    Country,
+    Data,
+    ParameterGroupMetadata,
+    Rt
+} from "@/types";
 import Collapsible from "@/components/Collapsible.vue";
 import EditParameters from "./EditParameters.vue";
 import Phases from "./Phases.vue";

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div id="countries" class="mb-3">
-      <h3>Countries</h3>
+      <h3>Country</h3>
       <select id="select-country" v-model="selectedCountry" class="form-control">
         <option v-for="country in countries" :value="country.code">{{country.name}}</option>
       </select>

--- a/src/app/static/src/components/parameters/Parameters.vue
+++ b/src/app/static/src/components/parameters/Parameters.vue
@@ -1,5 +1,11 @@
 <template>
   <div>
+    <div id="countries" class="mb-3">
+      <h3>Countries</h3>
+      <select id="select-country" v-model="selectedCountry" class="form-control">
+        <option v-for="country in countries" :value="country.code">{{country.name}}</option>
+      </select>
+    </div>
     <div v-for="paramGroup in paramGroupMetadata" :key="paramGroup.id">
       <div>
         <collapsible class="collapsible mt-2" :initial-open="false" :heading="paramGroup.label">
@@ -52,7 +58,7 @@ import {
     DynamicForm,
     DynamicFormData
 } from "@reside-ic/vue-dynamic-form";
-import { Data, ParameterGroupMetadata, Rt } from "@/types";
+import {Country, Data, ParameterGroupMetadata, Rt} from "@/types";
 import Collapsible from "@/components/Collapsible.vue";
 import EditParameters from "./EditParameters.vue";
 import Phases from "./Phases.vue";
@@ -63,6 +69,7 @@ interface Props {
     paramValues: Data
     forecastStart: Date
     forecastEnd: Date
+    countries: Country[]
 }
 
 export default defineComponent({
@@ -78,7 +85,8 @@ export default defineComponent({
         paramGroupMetadata: Array,
         paramValues: Object,
         forecastStart: Date,
-        forecastEnd: Date
+        forecastEnd: Date,
+        countries: Array
     },
     setup(props: Props, context) {
         const paramsModalOpen = ref(false);
@@ -87,6 +95,15 @@ export default defineComponent({
 
         const editParamGroup = computed(() => {
             return props.paramGroupMetadata.find((g) => g.id === editParamGroupId.value);
+        });
+
+        const selectedCountry = computed({
+            get: () => {
+                return props.paramValues.region as string;
+            },
+            set: (value: string) => {
+                context.emit("updateCountry", value);
+            }
         });
 
         function editParameters(paramGroupId: string) {
@@ -144,6 +161,7 @@ export default defineComponent({
         }
 
         return {
+            selectedCountry,
             paramsModalOpen,
             phasesModalOpen,
             editParamGroupId,

--- a/src/app/static/src/store/actions.ts
+++ b/src/app/static/src/store/actions.ts
@@ -66,5 +66,9 @@ export const actions: ActionTree<RootState, RootState> = {
     async updateParameterValues({ commit, dispatch }, newValues) {
         commit("setParameterValues", newValues);
         dispatch("getResults");
+    },
+    async updateCountry({ commit, dispatch }, newValue) {
+        commit("setCountry", newValue);
+        dispatch("getResults");
     }
 };

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -27,6 +27,10 @@ export const mutations = {
     setParameterValues(state: RootState, paramValues: Data): void {
         state.paramValues = paramValues;
     },
+    setCountry(state: RootState, countryCode: string): void {
+        state.paramValues!!.region = countryCode;
+        //TODO: Update population parameter value based on country population
+    },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;
     },

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -29,7 +29,6 @@ export const mutations = {
     },
     setCountry(state: RootState, countryCode: string): void {
         state.paramValues!.region = countryCode;
-        // TODO: Update population parameter value based on country population
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -28,8 +28,8 @@ export const mutations = {
         state.paramValues = paramValues;
     },
     setCountry(state: RootState, countryCode: string): void {
-        state.paramValues!!.region = countryCode;
-        //TODO: Update population parameter value based on country population
+        state.paramValues!.region = countryCode;
+        // TODO: Update population parameter value based on country population
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -6,6 +6,8 @@
                   :paramValues="paramValues"
                   :forecastStart="forecastStart"
                   :forecastEnd="forecastEnd"
+                  :countries="countries"
+                  @updateCountry="updateCountry"
                   @updateMetadata="setParameterMetadata"
                   @updateValues="updateParameterValues"></Parameters>
     </div>
@@ -66,6 +68,7 @@ export default defineComponent({
             "getMetadata",
             "getCountries",
             "getResults",
+            "updateCountry",
             "updateParameterValues"
         ]),
         ...mapMutations([

--- a/src/app/static/src/views/Home.vue
+++ b/src/app/static/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="home row">
     <div class="col-md-4">
-      <Parameters class="parameters" v-if="metadata"
+      <Parameters class="parameters" v-if="metadata && countries"
                   :paramGroupMetadata="metadata.parameterGroups"
                   :paramValues="paramValues"
                   :forecastStart="forecastStart"

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -67,9 +67,9 @@ describe("Parameters", () => {
     const forecastEnd = new Date("2021-06-01");
 
     const countries = [
-        { code: "GBR", name: "United Kingdom" },
-        { code: "FRA", name: "France" },
-        { code: "IRE", name: "Ireland" }
+        { code: "GBR", name: "United Kingdom", public: true },
+        { code: "FRA", name: "France", public: true },
+        { code: "IRE", name: "Ireland", public: true }
     ];
 
     function getWrapper() {
@@ -91,12 +91,33 @@ describe("Parameters", () => {
         const countrySelect = countryDiv.find("select");
         expect((countrySelect.element as HTMLSelectElement).value).toBe("FRA");
         const options = countrySelect.findAll("option");
-        expect(options.at(0).attributes("value")).toBe("GBR");
-        expect(options.at(0).text()).toBe("United Kingdom");
-        expect(options.at(1).attributes("value")).toBe("FRA");
-        expect(options.at(1).text()).toBe("France");
-        expect(options.at(2).attributes("value")).toBe("IRE");
-        expect(options.at(2).text()).toBe("Ireland");
+        // countries should be sorted by name
+        expect(options.at(0).attributes("value")).toBe("FRA");
+        expect(options.at(0).text()).toBe("France");
+        expect(options.at(1).attributes("value")).toBe("IRE");
+        expect(options.at(1).text()).toBe("Ireland");
+        expect(options.at(2).attributes("value")).toBe("GBR");
+        expect(options.at(2).text()).toBe("United Kingdom");
+    });
+
+    it("countries which are not public are not rendered", () => {
+        const wrapper = shallowMount(Parameters, {
+            propsData: {
+                paramGroupMetadata,
+                paramValues,
+                forecastStart,
+                forecastEnd,
+                countries: [
+                    ...countries,
+                    { code: "TEST", name: "TEST COUNTRY", public: false }
+                ]
+            }
+        });
+        const options = wrapper.findAll("#select-country option");
+        expect(options.length).toBe(3);
+        expect(options.at(0).attributes("value")).toBe("FRA");
+        expect(options.at(1).attributes("value")).toBe("IRE");
+        expect(options.at(2).attributes("value")).toBe("GBR");
     });
 
     it("renders collapsible dynamicForm and phases parameter groups", () => {
@@ -137,7 +158,7 @@ describe("Parameters", () => {
         const wrapper = getWrapper();
         await wrapper.findAll("#select-country option").at(2).setSelected();
         expect(wrapper.emitted("updateCountry")?.length).toBe(1);
-        expect(wrapper.emitted("updateCountry")![0][0]).toBe("IRE");
+        expect(wrapper.emitted("updateCountry")![0][0]).toBe("GBR");
     });
 
     it("Edit components are not rendered before group is selected", () => {

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -88,16 +88,16 @@ describe("Parameters", () => {
         const wrapper = getWrapper();
         const countryDiv = wrapper.find("#countries");
         expect(countryDiv.find("label.h3").text()).toBe("Country");
-        const countrySelect = countryDiv.find("select");
-        expect((countrySelect.element as HTMLSelectElement).value).toBe("FRA");
-        const options = countrySelect.findAll("option");
+        const countrySelect = countryDiv.find("v-select-stub");
+        expect(countrySelect.props("value").code).toBe("FRA");
+        const options = countrySelect.props("options");
         // countries should be sorted by name
-        expect(options.at(0).attributes("value")).toBe("FRA");
-        expect(options.at(0).text()).toBe("France");
-        expect(options.at(1).attributes("value")).toBe("IRE");
-        expect(options.at(1).text()).toBe("Ireland");
-        expect(options.at(2).attributes("value")).toBe("GBR");
-        expect(options.at(2).text()).toBe("United Kingdom");
+        expect(options[0].code).toBe("FRA");
+        expect(options[0].name).toBe("France");
+        expect(options[1].code).toBe("IRE");
+        expect(options[1].name).toBe("Ireland");
+        expect(options[2].code).toBe("GBR");
+        expect(options[2].name).toBe("United Kingdom");
     });
 
     it("countries which are not public are not rendered", () => {
@@ -113,11 +113,11 @@ describe("Parameters", () => {
                 ]
             }
         });
-        const options = wrapper.findAll("#select-country option");
+        const options = wrapper.find("#countries v-select-stub").props("options");
         expect(options.length).toBe(3);
-        expect(options.at(0).attributes("value")).toBe("FRA");
-        expect(options.at(1).attributes("value")).toBe("IRE");
-        expect(options.at(2).attributes("value")).toBe("GBR");
+        expect(options[0].code).toBe("FRA");
+        expect(options[1].code).toBe("IRE");
+        expect(options[2].code).toBe("GBR");
     });
 
     it("renders collapsible dynamicForm and phases parameter groups", () => {
@@ -156,7 +156,8 @@ describe("Parameters", () => {
 
     it("selecting country emits updateCountry event", async () => {
         const wrapper = getWrapper();
-        await wrapper.findAll("#select-country option").at(2).setSelected();
+        const newCountry = { code: "GBR", name: "United Kingdom", public: true };
+        await wrapper.find("#countries v-select-stub").vm.$emit("input", newCountry);
         expect(wrapper.emitted("updateCountry")?.length).toBe(1);
         expect(wrapper.emitted("updateCountry")![0][0]).toBe("GBR");
     });

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -87,7 +87,7 @@ describe("Parameters", () => {
     it("renders countries", () => {
         const wrapper = getWrapper();
         const countryDiv = wrapper.find("#countries");
-        expect(countryDiv.find("h3").text()).toBe("Country");
+        expect(countryDiv.find("label.h3").text()).toBe("Country");
         const countrySelect = countryDiv.find("select");
         expect((countrySelect.element as HTMLSelectElement).value).toBe("FRA");
         const options = countrySelect.findAll("option");

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -67,9 +67,9 @@ describe("Parameters", () => {
     const forecastEnd = new Date("2021-06-01");
 
     const countries = [
-      {code: "GBR", name: "United Kingdom"},
-      {code: "FRA", name: "France"},
-      {code: "IRE", name: "Ireland"}
+        { code: "GBR", name: "United Kingdom" },
+        { code: "FRA", name: "France" },
+        { code: "IRE", name: "Ireland" }
     ];
 
     function getWrapper() {
@@ -136,8 +136,8 @@ describe("Parameters", () => {
     it("selecting country emits updateCountry event", async () => {
         const wrapper = getWrapper();
         await wrapper.findAll("#select-country option").at(2).setSelected();
-        expect(wrapper.emitted("updateCountry")!!.length).toBe(1);
-        expect(wrapper.emitted("updateCountry")!![0][0]).toBe("IRE");
+        expect(wrapper.emitted("updateCountry")?.length).toBe(1);
+        expect(wrapper.emitted("updateCountry")![0][0]).toBe("IRE");
     });
 
     it("Edit components are not rendered before group is selected", () => {

--- a/src/app/static/tests/unit/components/parameters/parameters.test.ts
+++ b/src/app/static/tests/unit/components/parameters/parameters.test.ts
@@ -50,6 +50,7 @@ describe("Parameters", () => {
     ] as any;
 
     const paramValues = {
+        region: "FRA",
         pg1: {
             value1: "old1",
             value2: "unchanged"
@@ -65,16 +66,38 @@ describe("Parameters", () => {
     const forecastStart = new Date("2021-01-01");
     const forecastEnd = new Date("2021-06-01");
 
+    const countries = [
+      {code: "GBR", name: "United Kingdom"},
+      {code: "FRA", name: "France"},
+      {code: "IRE", name: "Ireland"}
+    ];
+
     function getWrapper() {
         return shallowMount(Parameters, {
             propsData: {
                 paramGroupMetadata,
                 paramValues,
                 forecastStart,
-                forecastEnd
+                forecastEnd,
+                countries
             }
         });
     }
+
+    it("renders countries", () => {
+        const wrapper = getWrapper();
+        const countryDiv = wrapper.find("#countries");
+        expect(countryDiv.find("h3").text()).toBe("Country");
+        const countrySelect = countryDiv.find("select");
+        expect((countrySelect.element as HTMLSelectElement).value).toBe("FRA");
+        const options = countrySelect.findAll("option");
+        expect(options.at(0).attributes("value")).toBe("GBR");
+        expect(options.at(0).text()).toBe("United Kingdom");
+        expect(options.at(1).attributes("value")).toBe("FRA");
+        expect(options.at(1).text()).toBe("France");
+        expect(options.at(2).attributes("value")).toBe("IRE");
+        expect(options.at(2).text()).toBe("Ireland");
+    });
 
     it("renders collapsible dynamicForm and phases parameter groups", () => {
         const wrapper = getWrapper();
@@ -108,6 +131,13 @@ describe("Parameters", () => {
         buttons.wrappers.forEach((button) => {
             expect(button.text()).toBe("Edit");
         });
+    });
+
+    it("selecting country emits updateCountry event", async () => {
+        const wrapper = getWrapper();
+        await wrapper.findAll("#select-country option").at(2).setSelected();
+        expect(wrapper.emitted("updateCountry")!!.length).toBe(1);
+        expect(wrapper.emitted("updateCountry")!![0][0]).toBe("IRE");
     });
 
     it("Edit components are not rendered before group is selected", () => {
@@ -199,6 +229,7 @@ describe("Parameters", () => {
         const updateValues = wrapper.emitted("updateValues")!;
         expect(updateValues.length).toBe(1);
         expect(updateValues[0][0]).toStrictEqual({
+            region: "FRA",
             pg1: {
                 value1: "new1",
                 value2: "unchanged"
@@ -240,6 +271,7 @@ describe("Parameters", () => {
 
         expect(wrapper.emitted("updateValues")?.length).toBe(1);
         expect(wrapper.emitted("updateValues")![0][0]).toStrictEqual({
+            region: "FRA",
             pg1: {
                 value1: "old1",
                 value2: "unchanged"

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -69,6 +69,16 @@ describe("actions", () => {
         expect(commit.mock.calls[3][1]).toBe(false);
     });
 
+    it("updates country", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        await (actions.updateCountry as any)({ commit, dispatch }, "GBR");
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe("setCountry");
+        expect(commit.mock.calls[0][1]).toBe("GBR");
+        expect(dispatch.mock.calls.length).toBe(1);
+    });
+
     it("updates parameter values", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -36,6 +36,13 @@ describe("mutations", () => {
         });
     });
 
+    it("sets country", () => {
+        const paramValues = { region: "GBR" };
+        const state = mockRootState({ paramValues });
+        mutations.setCountry(state, "FRA");
+        expect(state.paramValues!!.region).toBe("FRA");
+    });
+
     it("sets parameter values", () => {
         const state = mockRootState();
         const mockParamValues = { grp1: { param1: "value1" } };

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -40,7 +40,7 @@ describe("mutations", () => {
         const paramValues = { region: "GBR" };
         const state = mockRootState({ paramValues });
         mutations.setCountry(state, "FRA");
-        expect(state.paramValues!!.region).toBe("FRA");
+        expect(state.paramValues!.region).toBe("FRA");
     });
 
     it("sets parameter values", () => {

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -102,7 +102,7 @@ describe("Home", () => {
         expect(mockGetResults.mock.calls.length).toBe(0);
     });
 
-    it("renders Charts and Parameters component with expected props", () => {
+    it("renders components with expected props", () => {
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
                 metadata: {
@@ -114,7 +114,8 @@ describe("Home", () => {
                     ]
                 } as any,
                 results: { value: "results" },
-                paramValues: { value: "paramValue" }
+                paramValues: { value: "paramValue" },
+                countries: [{ code: "GBR", name: "United Kingdom", public: true }]
             }),
             getters: {
                 ...getters,
@@ -139,6 +140,7 @@ describe("Home", () => {
         expect(parameters.props("paramValues")).toStrictEqual({ value: "paramValue" });
         expect(parameters.props("forecastStart")).toStrictEqual(new Date("2021-01-01"));
         expect(parameters.props("forecastEnd")).toStrictEqual(new Date("2021-06-01"));
+        expect(parameters.props("countries")).toStrictEqual([{ code: "GBR", name: "United Kingdom", public: true }]);
     });
 
     it("does not render Charts or Parameters component if no metadata", () => {
@@ -183,6 +185,23 @@ describe("Home", () => {
         const fetchingResults = wrapper.find("#fetching-results");
         expect(fetchingResults.text()).toBe("Updating analysis...");
         expect(fetchingResults.find("loading-spinner-stub").exists()).toBe(true);
+    });
+
+    it("dispatches updateCountry on update emitted from Parameters", () => {
+        const mockUpdateCountry = jest.fn();
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                metadata: {} as any
+            }),
+            actions: {
+                updateCountry: mockUpdateCountry
+            }
+        });
+
+        const wrapper = shallowMount(Home, { store });
+        wrapper.findComponent(Parameters).vm.$emit("updateCountry", "FRA");
+        expect(mockUpdateCountry.mock.calls.length).toBe(1);
+        expect(mockUpdateCountry.mock.calls[0][1]).toBe("FRA");
     });
 
     it("commits parameter metadata on update emitted from Parameters", async () => {

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -148,7 +148,8 @@ describe("Home", () => {
             state: mockRootState({
                 metadata: null,
                 results: { value: "results" },
-                paramValues: { value: "chartLayoutData" }
+                paramValues: { value: "chartLayoutData" },
+                countries: [{ code: "TEST", name: "test", public: false }]
             })
         });
 
@@ -156,6 +157,27 @@ describe("Home", () => {
         const charts = wrapper.findComponent(Charts);
         expect(charts.exists()).toBe(false);
 
+        const parameters = wrapper.findComponent(Parameters);
+        expect(parameters.exists()).toBe(false);
+    });
+
+    it("does not render Parameters component if no countries", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                metadata: {
+                    charts: [
+                        { value: "metadata" }
+                    ],
+                    parameterGroups: [
+                        { value: "paramMetadata" }
+                    ]
+                } as any,
+                results: { value: "results" },
+                paramValues: { value: "chartLayoutData" },
+                countries: null
+            })
+        });
+        const wrapper = shallowMount(Home, { store });
         const parameters = wrapper.findComponent(Parameters);
         expect(parameters.exists()).toBe(false);
     });
@@ -191,7 +213,8 @@ describe("Home", () => {
         const mockUpdateCountry = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-                metadata: {} as any
+                metadata: {} as any,
+                countries: [] as any
             }),
             actions: {
                 updateCountry: mockUpdateCountry
@@ -208,7 +231,8 @@ describe("Home", () => {
         const mockSetParameterMetadata = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-                metadata: {} as any
+                metadata: {} as any,
+                countries: [] as any
             }),
             mutations: {
                 setParameterMetadata: mockSetParameterMetadata
@@ -228,7 +252,8 @@ describe("Home", () => {
         const mockUpdateParameterValues = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-                metadata: {} as any
+                metadata: {} as any,
+                countries: [] as any
             }),
             actions: {
                 updateParameterValues: mockUpdateParameterValues


### PR DESCRIPTION
This branch implements the country drop down. When a new country is selected, data is re-fetched for the updated country. 
I've named this 'Country' in the UI rather than 'Region', as I thought that would be less confusing. I don't think we're expecting any non-national regions. We do have an unfortunate combination of region and country in the code - the cometr endpoint is `/countries` but the parameter required by the model is `region`. I've tried to standardise on `country/countries`.

I'm sorting countries in the drop down list by name (the actual text shown), and am also filtering out any non-public countries (i.e. TEST)