### PR TITLE
mrc-2466 Stop accidental phase add on mouseup, and allow phase drag to continue when cursor overtakes slider

### DIFF
--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -34,7 +34,7 @@
                  @click.stop="">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>
               <button type="button"
-                      class="close float-right mr-1" aria-label="Delete"
+                      class="close float-right mr-1 disable-select" aria-label="Delete"
                       @click="deletePhase(index)">
                 <span aria-hidden="true">&times;</span>
               </button>
@@ -50,7 +50,8 @@
                   <div class="phase-start">Start: {{displayPhases[index].start}}</div>
                   <div class="phase-end">End: {{displayPhases[index].end}}</div>
                 </div>
-                <div class="phase-rt">Rt:
+                <div class="phase-rt">
+                  <span class="disable-select">Rt:</span>
                   <input
                     :id="`phase-rt-${index}`"
                     class="phase-rt-input"

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -14,7 +14,7 @@
       <div class="phase-editor" @mouseup="mouseUp">
         <div class="phases-container">
           <div ref="rail" class="rail"
-               @click="addPhase">
+               @mousedown="addPhase">
             <div v-for="(value, index) in sliderValues"
                  :id="`slider-${index}-${sliderUpdateKeys[index]}`"
                  :key="index"
@@ -29,7 +29,7 @@
                  :aria-valuemax="sliderMax(index)"
                  :aria-label="`Phase ${displayPhases[index].index}`"
                  @mousemove="mouseMove(index, $event)"
-                 @mousedown="mouseDown(index, $event)"
+                 @mousedown.stop="mouseDown(index, $event)"
                  @mouseup="mouseUp"
                  @click.stop="">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>

--- a/src/app/static/src/components/parameters/EditPhases.vue
+++ b/src/app/static/src/components/parameters/EditPhases.vue
@@ -29,14 +29,14 @@
                  :aria-valuetext="displayPhases[index].start"
                  :aria-valuemax="sliderMax(index)"
                  :aria-label="`Phase ${displayPhases[index].index}`"
-                 @mousedown.stop="mouseDown(index, $event)"
+                 @mousedown.stop.prevent="mouseDown(index, $event)"
                  @mouseup="mouseUp"
                  @click.stop="">
               <div class="slider-spike" :class="phaseClassFromIndex(index+1)"></div>
               <button type="button"
-                      class="close float-right mr-1 disable-select" aria-label="Delete"
+                      class="close float-right mr-1" aria-label="Delete"
                       @click="deletePhase(index)">
-                <span aria-hidden="true">&times;</span>
+                <span aria-hidden="true" class="disable-select">&times;</span>
               </button>
               <div class="slider-text">
                 <div class="phase-dates disable-select">
@@ -204,7 +204,8 @@ export default defineComponent({
         };
 
         const mouseMove = (event: MouseEvent) => {
-            if (movingSlider.value !== null && moveStartOffset.value !== null && moveStartDays.value !== null) {
+            if (movingSlider.value !== null && moveStartOffset.value !== null
+                   && moveStartDays.value !== null) {
                 const index = movingSlider.value;
                 const offsetDiff = event.clientX - moveStartOffset.value;
                 const valueDiff = sliderValueAsDays(offsetDiff);

--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -37,11 +37,12 @@ describe("EditPhases", () => {
         setRailWidth(wrapper);
 
         const slider = wrapper.findAll(".slider").at(sliderIdx);
+        const rail = wrapper.find(".rail");
 
-        slider.trigger("mousedown", { offsetX: 0 });
+        slider.trigger("mousedown", { clientX: 0 });
         await Vue.nextTick();
 
-        slider.trigger("mousemove", { offsetX: dragAsPercent * 10 });
+        rail.trigger("mousemove", { clientX: dragAsPercent * 10 });
         await Vue.nextTick();
 
         slider.trigger("mouseup");
@@ -325,7 +326,7 @@ describe("EditPhases", () => {
     it("clicking on timeline adds a new first phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);
-        await wrapper.find(".rail").trigger("click", { offsetX: 0 });
+        await wrapper.find(".rail").trigger("mousedown", { offsetX: 0 });
 
         const { sliderValues } = wrapper.vm.$data;
         expect(sliderValues.length).toBe(3);
@@ -364,7 +365,7 @@ describe("EditPhases", () => {
     it("clicking on timeline adds a new last phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);
-        await wrapper.find(".rail").trigger("click", { offsetX: 600 });
+        await wrapper.find(".rail").trigger("mousedown", { offsetX: 600 });
 
         const { sliderValues } = wrapper.vm.$data;
         expect(sliderValues.length).toBe(3);
@@ -403,7 +404,7 @@ describe("EditPhases", () => {
     it("clicking on timeline adds a new intermediate phase", async () => {
         const wrapper = getWrapper();
         setRailWidth(wrapper);
-        await wrapper.find(".rail").trigger("click", { offsetX: 200 });
+        await wrapper.find(".rail").trigger("mousedown", { offsetX: 200 });
 
         const { sliderValues } = wrapper.vm.$data;
         expect(sliderValues.length).toBe(3);


### PR DESCRIPTION
This branch:
- Prevents the accidental adding of phases when mouseup on rail (phase slider container) during drag, by handling addPhase in mousedown, and stopping that event propagating from the phase sliders
- Fixes drag stopping when cursor overtakes slider, by handling the mousemove from the rail. Use `clientX` rather than `offsetX` to calculate move distance as this will be consistent between event targets
- Fixes pre-existing bug where the new number of days was being calculated as offset from current value rather than move start value, which is what we were using to calculate the distance moved. I think we got away with that before when using `offsetX`, but it became very obvious with `clientX`
- Prevent Rt span and delete button from being selected.