### PR TITLE
mrc-2554 Update healthcare parameters when country is changed

### DIFF
--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -1,11 +1,11 @@
 import { RootState } from "@/store/state";
 import {
-    ApiInfo,
-    Metadata,
-    Data,
-    ParameterGroupMetadata,
-    ErrorInfo,
-    Country
+  ApiInfo,
+  Metadata,
+  Data,
+  ParameterGroupMetadata,
+  ErrorInfo,
+  Country, ParameterValues
 } from "@/types";
 
 export const mutations = {
@@ -24,11 +24,22 @@ export const mutations = {
     setParameterMetadata(state: RootState, paramMetadata: ParameterGroupMetadata[]): void {
         state.metadata!.parameterGroups = paramMetadata;
     },
-    setParameterValues(state: RootState, paramValues: Data): void {
+    setParameterValues(state: RootState, paramValues: ParameterValues): void {
         state.paramValues = paramValues;
     },
     setCountry(state: RootState, countryCode: string): void {
-        state.paramValues!.region = countryCode;
+        //state.paramValues!.region = countryCode;
+        const country = state.countries!.find(country => country.code == countryCode)!;
+        //state.paramValues!.healthcare.generalBeds = country.capacityGeneral;
+        //state.paramValues!.healthcare.criticalBeds = country.capacityICU;
+        state.paramValues = {
+            ...state.paramValues,
+            region: countryCode,
+            healthcare: {
+                generalBeds: country.capacityGeneral,
+                criticalBeds: country.capacityICU
+            }
+        }
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -1,13 +1,13 @@
 import { RootState } from "@/store/state";
 import {
-  ApiInfo,
-  Metadata,
-  Data,
-  ParameterGroupMetadata,
-  ErrorInfo,
-  Country
+    ApiInfo,
+    Metadata,
+    Data,
+    ParameterGroupMetadata,
+    ErrorInfo,
+    Country
 } from "@/types";
-import {updateParameterInGroup} from "@/utils/parameters";
+import { updateParameterInGroup } from "@/utils/parameters";
 
 export const mutations = {
     setApiInfo(state: RootState, apiInfo: ApiInfo): void {
@@ -30,11 +30,9 @@ export const mutations = {
     },
     setCountry(state: RootState, countryCode: string): void {
         state.paramValues!.region = countryCode;
-        const country = state.countries!.find(country => country.code == countryCode)!;
-        //state.paramValues!.healthcare.generalBeds = country.capacityGeneral; //TODO: wrap this into updateParameterInGroup
-        //state.paramValues!.healthcare.criticalBeds = country.capacityICU;
-        updateParameterInGroup(state, "healthcare", "generalBeds", country.capacityGeneral);
-        updateParameterInGroup(state, "healthcare", "criticalBeds", country.capacityICU)
+        const newCountry = state.countries!.find((country) => country.code === countryCode)!;
+        updateParameterInGroup(state, "healthcare", "generalBeds", newCountry.capacityGeneral);
+        updateParameterInGroup(state, "healthcare", "criticalBeds", newCountry.capacityICU);
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;

--- a/src/app/static/src/store/mutations.ts
+++ b/src/app/static/src/store/mutations.ts
@@ -28,18 +28,13 @@ export const mutations = {
         state.paramValues = paramValues;
     },
     setCountry(state: RootState, countryCode: string): void {
-        //state.paramValues!.region = countryCode;
+        state.paramValues!.region = countryCode;
         const country = state.countries!.find(country => country.code == countryCode)!;
-        //state.paramValues!.healthcare.generalBeds = country.capacityGeneral;
-        //state.paramValues!.healthcare.criticalBeds = country.capacityICU;
-        state.paramValues = {
-            ...state.paramValues,
-            region: countryCode,
-            healthcare: {
-                generalBeds: country.capacityGeneral,
-                criticalBeds: country.capacityICU
-            }
-        }
+        //Because parameter values are kept separately from the metaata for dyanmic form used
+        //to update those values, we need to update them both
+        state.paramValues!.healthcare.generalBeds = country.capacityGeneral;
+        state.paramValues!.healthcare.criticalBeds = country.capacityICU;
+
     },
     setFetchingResults(state: RootState, fetchingResults: boolean): void {
         state.fetchingResults = fetchingResults;

--- a/src/app/static/src/store/state.ts
+++ b/src/app/static/src/store/state.ts
@@ -1,9 +1,9 @@
 import {
-    ApiInfo,
-    Country,
-    Data,
-    ErrorInfo,
-    Metadata
+  ApiInfo,
+  Country,
+  Data,
+  ErrorInfo,
+  Metadata, ParameterValues
 } from "@/types";
 
 export interface RootState {
@@ -11,7 +11,7 @@ export interface RootState {
   metadata: Metadata | null
   countries: Country[] | null
   results: Data | null
-  paramValues: Data | null
+  paramValues: ParameterValues | null
   fetchingResults: boolean
   errors: ErrorInfo[]
 }

--- a/src/app/static/src/store/state.ts
+++ b/src/app/static/src/store/state.ts
@@ -1,9 +1,9 @@
 import {
-  ApiInfo,
-  Country,
-  Data,
-  ErrorInfo,
-  Metadata
+    ApiInfo,
+    Country,
+    Data,
+    ErrorInfo,
+    Metadata
 } from "@/types";
 
 export interface RootState {

--- a/src/app/static/src/types.ts
+++ b/src/app/static/src/types.ts
@@ -51,11 +51,20 @@ export interface Metadata {
 export interface Country {
     code: string,
     name: string,
-    public: boolean
+    public: boolean,
+    capacityGeneral: number,
+    capacityICU: number
 }
 
 export interface Data {
-  [k: string]: unknown;
+    [k: string]: unknown;
+}
+
+export interface ParameterValues extends Data {
+    healthcare: {
+        generalBeds: number,
+        criticalBeds: number
+    }
 }
 
 export interface ErrorInfo {

--- a/src/app/static/src/utils/parameters.ts
+++ b/src/app/static/src/utils/parameters.ts
@@ -1,20 +1,29 @@
-import {RootState} from "@/store/state";
+import { RootState } from "@/store/state";
 import {
-  DynamicControl,
-  DynamicControlGroup,
-  DynamicControlSection, DynamicFormMeta
+    DynamicControl,
+    DynamicControlGroup,
+    DynamicControlSection,
+    DynamicFormMeta
 } from "@reside-ic/vue-dynamic-form";
 
-export const updateParameterInGroup = (state: RootState, parameterGroup: string,
-                                         parameterName: string, parameterValue: string | number) => {
-    //Because parameter values are kept separately from the metadata for dynamic form used
-    //to update those values, we need to update them both
-    // @ts-ignore
-    state.paramValues![parameterGroup]![parameterName] = parameterValue;
+export const updateParameterInGroup = (
+    state: RootState,
+    parameterGroup: string,
+    parameterName: string,
+    parameterValue: string | number
+): void => {
+    // Because parameter values are kept separately from the metadata for dynamic form used
+    // to update those values, we need to update them both
+    const paramValueGroup = (state.paramValues![parameterGroup] as Record<string, unknown>)!;
+    paramValueGroup[parameterName] = parameterValue;
 
-    const group = state.metadata!.parameterGroups.find(group => group.id == parameterGroup);
-    const groupControls = (group!.config as DynamicFormMeta).controlSections.map((section: DynamicControlSection) => section.controlGroups.map((controlGroup: DynamicControlGroup) => controlGroup.controls)).flat().flat();
-    const control = groupControls.find((control: DynamicControl) => control.name == parameterName)!;
-    control.value = parameterValue;
-    console.log("Update parameter group to:" + JSON.stringify(group))
+    const paramGroup = state.metadata!.parameterGroups.find((group) => group.id === parameterGroup);
+    const groupControls = (paramGroup!.config as DynamicFormMeta).controlSections
+        .map((section: DynamicControlSection) => section.controlGroups
+            .map((controlGroup: DynamicControlGroup) => controlGroup.controls))
+        .flat().flat();
+    const paramControl = groupControls.find(
+        (control: DynamicControl) => control.name === parameterName
+    )!;
+    paramControl.value = parameterValue;
 };

--- a/src/app/static/src/utils/parameters.ts
+++ b/src/app/static/src/utils/parameters.ts
@@ -19,9 +19,8 @@ export const updateParameterInGroup = (
 
     const paramGroup = state.metadata!.parameterGroups.find((group) => group.id === parameterGroup);
     const groupControls = (paramGroup!.config as DynamicFormMeta).controlSections
-        .map((section: DynamicControlSection) => section.controlGroups
-            .map((controlGroup: DynamicControlGroup) => controlGroup.controls))
-        .flat().flat();
+        .flatMap((section: DynamicControlSection) => section.controlGroups
+            .flatMap((controlGroup: DynamicControlGroup) => controlGroup.controls));
     const paramControl = groupControls.find(
         (control: DynamicControl) => control.name === parameterName
     )!;

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -51,7 +51,7 @@ describe("actions", () => {
         const mockResults = { time_series: [] };
         mockAxios.onPost("/results")
             .reply(200, mockSuccess(mockResults));
-        const state = mockRootState({ paramValues: { param1: "value1" } as any });
+        const state = mockRootState({ paramValues: { param1: "value1" } });
 
         const commit = jest.fn();
         await (actions.getResults as any)({ commit, state });

--- a/src/app/static/tests/unit/store/actions.test.ts
+++ b/src/app/static/tests/unit/store/actions.test.ts
@@ -51,7 +51,7 @@ describe("actions", () => {
         const mockResults = { time_series: [] };
         mockAxios.onPost("/results")
             .reply(200, mockSuccess(mockResults));
-        const state = mockRootState({ paramValues: { param1: "value1" } });
+        const state = mockRootState({ paramValues: { param1: "value1" } as any });
 
         const commit = jest.fn();
         await (actions.getResults as any)({ commit, state });

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -1,3 +1,4 @@
+import { DynamicFormMeta } from "@reside-ic/vue-dynamic-form";
 import { mutations } from "@/store/mutations";
 import { mockRootState } from "../../mocks";
 
@@ -37,15 +38,56 @@ describe("mutations", () => {
     });
 
     it("sets country", () => {
-        const paramValues = { region: "GBR" } as any;
-        const state = mockRootState({ paramValues });
+        const countries = [
+            { code: "GBR", capacityGeneral: 1000, capacityICU: 10 },
+            { code: "FRA", capacityGeneral: 2000, capacityICU: 20 }
+        ] as any;
+        const paramValues = {
+            region: "GBR",
+            healthcare: {
+                generalBeds: 1000,
+                criticalBeds: 10
+            }
+        };
+        const metadata = {
+            parameterGroups: [
+                {
+                    id: "anotherGroup"
+                },
+                {
+                    id: "healthcare",
+                    config: {
+                        controlSections: [
+                            {
+                                controlGroups: [
+                                    {
+                                        controls: [
+                                            { name: "generalBeds", value: 1000 },
+                                            { name: "criticalBeds", value: 10 }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        } as any;
+        const state = mockRootState({ countries, paramValues, metadata });
         mutations.setCountry(state, "FRA");
         expect(state.paramValues!.region).toBe("FRA");
+        const healthcare = state.paramValues!.healthcare as Record<string, any>;
+        expect(healthcare.generalBeds).toBe(2000);
+        expect(healthcare.criticalBeds).toBe(20);
+        const formMeta = state.metadata!.parameterGroups[1].config as DynamicFormMeta;
+        const controlGroup = formMeta.controlSections[0].controlGroups[0];
+        expect(controlGroup.controls[0].value).toBe(2000);
+        expect(controlGroup.controls[1].value).toBe(20);
     });
 
     it("sets parameter values", () => {
         const state = mockRootState();
-        const mockParamValues = { grp1: { param1: "value1" } } as any;
+        const mockParamValues = { grp1: { param1: "value1" } };
         mutations.setParameterValues(state, mockParamValues);
         expect(state.paramValues).toBe(mockParamValues);
     });

--- a/src/app/static/tests/unit/store/mutations.test.ts
+++ b/src/app/static/tests/unit/store/mutations.test.ts
@@ -11,7 +11,7 @@ describe("mutations", () => {
 
     it("sets countries", () => {
         const state = mockRootState();
-        const mockCountries = [{ code: "NARN", name: "Narnia", public: true }];
+        const mockCountries = [{ code: "NARN", name: "Narnia", public: true } as any];
         mutations.setCountries(state, mockCountries);
         expect(state.countries).toBe(mockCountries);
     });
@@ -37,7 +37,7 @@ describe("mutations", () => {
     });
 
     it("sets country", () => {
-        const paramValues = { region: "GBR" };
+        const paramValues = { region: "GBR" } as any;
         const state = mockRootState({ paramValues });
         mutations.setCountry(state, "FRA");
         expect(state.paramValues!.region).toBe("FRA");
@@ -45,7 +45,7 @@ describe("mutations", () => {
 
     it("sets parameter values", () => {
         const state = mockRootState();
-        const mockParamValues = { grp1: { param1: "value1" } };
+        const mockParamValues = { grp1: { param1: "value1" } } as any;
         mutations.setParameterValues(state, mockParamValues);
         expect(state.paramValues).toBe(mockParamValues);
     });

--- a/src/app/static/tests/unit/utils/parameters.test.ts
+++ b/src/app/static/tests/unit/utils/parameters.test.ts
@@ -1,0 +1,102 @@
+import { updateParameterInGroup } from "@/utils/parameters";
+import { mockRootState } from "../../mocks";
+
+describe("parameters utils", () => {
+    it("updates parameter in group", () => {
+        const paramValues = {
+            pGroup: {
+                pName: "oldValue",
+                otherName: "someValue"
+            },
+            otherGroup: {}
+        };
+        const metadata = {
+            parameterGroups: [
+                {
+                    id: "pGroup",
+                    config: {
+                        controlSections: [
+                            {
+                                controlGroups: [
+                                    {
+                                        controls: [
+                                            { name: "anotherParamGroup", value: "anotherValue" }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                controlGroups: [
+                                    {
+                                        controls: [
+                                            { name: "otherName", value: "otherOldValue" },
+                                            { name: "pName", value: "oldValue" }
+                                        ]
+                                    },
+                                    {
+                                        controls: [
+                                            { name: "anotherControlGroup", value: 5 }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    id: "otherGroup"
+                }
+            ]
+        } as any;
+        const state = mockRootState({
+            paramValues,
+            metadata
+        });
+        updateParameterInGroup(state, "pGroup", "pName", "newValue");
+        expect(state.paramValues).toStrictEqual({
+            pGroup: {
+                pName: "newValue",
+                otherName: "someValue"
+            },
+            otherGroup: {}
+        });
+        expect(state.metadata).toStrictEqual({
+            parameterGroups: [
+                {
+                    id: "pGroup",
+                    config: {
+                        controlSections: [
+                            {
+                                controlGroups: [
+                                    {
+                                        controls: [
+                                            { name: "anotherParamGroup", value: "anotherValue" }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                controlGroups: [
+                                    {
+                                        controls: [
+                                            { name: "otherName", value: "otherOldValue" },
+                                            { name: "pName", value: "newValue" }
+                                        ]
+                                    },
+                                    {
+                                        controls: [
+                                            { name: "anotherControlGroup", value: 5 }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    id: "otherGroup"
+                }
+            ]
+        });
+    });
+});

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -18,7 +18,6 @@ import { getters } from "@/store/getters";
 import { mockRootState } from "../../mocks";
 
 const paramValues = {
-    healthcare:{ generalBeds: 0, criticalBeds: 0 },
     value: "chartLayoutData"
 };
 
@@ -122,46 +121,46 @@ describe("Home", () => {
     });
 
     it("renders components with expected props", () => {
-      const store = new Vuex.Store<RootState>({
-        state: mockRootState({
-          metadata: {
-            charts: [
-              {value: "metadata"}
-            ],
-            parameterGroups: [
-              {value: "paramMetadata"}
-            ]
-          } as any,
-          results: {value: "results"},
-          paramValues,
-          countries
-        }),
-        getters: {
-          ...getters,
-          forecastStart: () => new Date("2021-01-01"),
-          forecastEnd: () => new Date("2021-06-01"),
-          population: () => numericFormatter(1000000.09)
-        }
-      });
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                metadata: {
+                    charts: [
+                        { value: "metadata" }
+                    ],
+                    parameterGroups: [
+                        { value: "paramMetadata" }
+                    ]
+                } as any,
+                results: { value: "results" },
+                paramValues,
+                countries
+            }),
+            getters: {
+                ...getters,
+                forecastStart: () => new Date("2021-01-01"),
+                forecastEnd: () => new Date("2021-06-01"),
+                population: () => numericFormatter(1000000.09)
+            }
+        });
 
-      const wrapper = shallowMount(Home, {store});
-      const charts = wrapper.findComponent(Charts);
-      expect(charts.props("chartMetadata")).toStrictEqual([{value: "metadata"}]);
-      expect(charts.props("chartData")).toStrictEqual({value: "results"});
-      expect(charts.props("layoutData")).toStrictEqual({
-        paramValues,
-        population: 67890000
-      });
+        const wrapper = shallowMount(Home, { store });
+        const charts = wrapper.findComponent(Charts);
+        expect(charts.props("chartMetadata")).toStrictEqual([{ value: "metadata" }]);
+        expect(charts.props("chartData")).toStrictEqual({ value: "results" });
+        expect(charts.props("layoutData")).toStrictEqual({
+            params: paramValues,
+            population: 67890000
+        });
 
-      const parameters = wrapper.findComponent(Parameters);
-      expect(parameters.props("paramGroupMetadata")).toStrictEqual([
-        {value: "paramMetadata"}
-      ]);
-      expect(parameters.props("paramValues")).toStrictEqual({value: "paramValue"});
-      expect(parameters.props("population")).toStrictEqual("1.00m");
-      expect(parameters.props("forecastStart")).toStrictEqual(new Date("2021-01-01"));
+        const parameters = wrapper.findComponent(Parameters);
+        expect(parameters.props("paramGroupMetadata")).toStrictEqual([
+            { value: "paramMetadata" }
+        ]);
+        expect(parameters.props("paramValues")).toStrictEqual(paramValues);
+        expect(parameters.props("population")).toStrictEqual("1.00m");
+        expect(parameters.props("forecastStart")).toStrictEqual(new Date("2021-01-01"));
 
-      expect(parameters.props("countries")).toStrictEqual(countries);
+        expect(parameters.props("countries")).toStrictEqual(countries);
     });
 
     it("does not render Charts or Parameters component if no metadata", () => {

--- a/src/app/static/tests/unit/views/home.test.ts
+++ b/src/app/static/tests/unit/views/home.test.ts
@@ -14,6 +14,21 @@ import { RootState } from "@/store/state";
 import { getters } from "@/store/getters";
 import { mockRootState } from "../../mocks";
 
+const paramValues = {
+    healthcare:{ generalBeds: 0, criticalBeds: 0 },
+    value: "chartLayoutData"
+};
+
+const countries = [
+    {
+        code: "GBR",
+        name: "United Kingdom",
+        public: true,
+        capacityICU: 100,
+        capacityGeneral: 10000
+    }
+];
+
 describe("Home", () => {
     it("gets metadata, countries and results on mount", () => {
         const mockGetMetadata = jest.fn();
@@ -65,7 +80,7 @@ describe("Home", () => {
         const mockGetResults = jest.fn();
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
-                countries: [{ code: "NARN", name: "Narnia", public: true }]
+                countries
             }),
             actions: {
                 getMetadata: mockGetMetadata,
@@ -114,8 +129,8 @@ describe("Home", () => {
                     ]
                 } as any,
                 results: { value: "results" },
-                paramValues: { value: "paramValue" },
-                countries: [{ code: "GBR", name: "United Kingdom", public: true }]
+                paramValues,
+                countries
             }),
             getters: {
                 ...getters,
@@ -129,7 +144,7 @@ describe("Home", () => {
         expect(charts.props("chartMetadata")).toStrictEqual([{ value: "metadata" }]);
         expect(charts.props("chartData")).toStrictEqual({ value: "results" });
         expect(charts.props("layoutData")).toStrictEqual({
-            params: { value: "paramValue" },
+            paramValues,
             population: 67890000
         });
 
@@ -140,7 +155,7 @@ describe("Home", () => {
         expect(parameters.props("paramValues")).toStrictEqual({ value: "paramValue" });
         expect(parameters.props("forecastStart")).toStrictEqual(new Date("2021-01-01"));
         expect(parameters.props("forecastEnd")).toStrictEqual(new Date("2021-06-01"));
-        expect(parameters.props("countries")).toStrictEqual([{ code: "GBR", name: "United Kingdom", public: true }]);
+        expect(parameters.props("countries")).toStrictEqual(countries);
     });
 
     it("does not render Charts or Parameters component if no metadata", () => {
@@ -148,8 +163,8 @@ describe("Home", () => {
             state: mockRootState({
                 metadata: null,
                 results: { value: "results" },
-                paramValues: { value: "chartLayoutData" },
-                countries: [{ code: "TEST", name: "test", public: false }]
+                paramValues,
+                countries
             })
         });
 
@@ -173,7 +188,7 @@ describe("Home", () => {
                     ]
                 } as any,
                 results: { value: "results" },
-                paramValues: { value: "chartLayoutData" },
+                paramValues,
                 countries: null
             })
         });

--- a/src/config/cometr_version
+++ b/src/config/cometr_version
@@ -1,1 +1,1 @@
-main
+master


### PR DESCRIPTION
This branch updates the `generalBeds` and `criticalBeds` parameters when the selected country changed, setting them to the `capacityGeneral` and `capacityICU` values from the country metadata respectively. 

This is a bit more complicated than it should be, because the state's `paramValues` (sent to the backend to fetch results, and built from the values emitted from the parameters dynamic forms) and `metadata` (the dynamic form metadata, which includes control layout config as well as values) both need to be updated. A utils method has been created to help with this. 

This is necessary because the DynamicForm doesn't expect anything except itself to update both values and metadata. An enhancement to the form would be for it to deal with external updates to values by automatically updating metadata itself, so container apps would only need to update the values.  