### PR TITLE
mrc-2804 Add date axis to phases editor

### DIFF
--- a/src/app/static/tests/unit/components/parameters/editPhases.test.ts
+++ b/src/app/static/tests/unit/components/parameters/editPhases.test.ts
@@ -135,6 +135,44 @@ describe("EditPhases", () => {
         expect(modal.find("button.btn-secondary").text()).toBe("Cancel");
     });
 
+    it("renders date axis where forecast start is first day of month", () => {
+        // Total days = 31 (Jan) + 28 (Feb) + 31 (Mar) + 10 = 100
+        const propsData = {
+            open: true,
+            forecastStart,
+            forecastEnd: new Date("2021-04-10"),
+            paramGroup
+        };
+        const wrapper = mount(EditPhases, { propsData });
+        const monthStarts = wrapper.findAll(".date-axis .month-start");
+        expect(monthStarts.length).toBe(4);
+        expect(monthStarts.at(0).text()).toBe("Jan 2021");
+        expect(monthStarts.at(0).element.style.left).toBe("0%");
+        expect(monthStarts.at(1).text()).toBe("Feb 2021");
+        expect(monthStarts.at(1).element.style.left).toBe("31%");
+        expect(monthStarts.at(2).text()).toBe("Mar 2021");
+        expect(monthStarts.at(2).element.style.left).toBe("59%");
+        expect(monthStarts.at(3).text()).toBe("Apr 2021");
+        expect(monthStarts.at(3).element.style.left).toBe("90%");
+    });
+
+    it("renders date axis where forecast start is not first day of month", () => {
+        // Total days = 9 (Feb) + 31 (Mar) + 10 = 50
+        const propsData = {
+            open: true,
+            forecastStart: new Date("2021-02-20"),
+            forecastEnd: new Date("2021-04-10"),
+            paramGroup
+        };
+        const wrapper = mount(EditPhases, { propsData });
+        const monthStarts = wrapper.findAll(".date-axis .month-start");
+        expect(monthStarts.length).toBe(2);
+        expect(monthStarts.at(0).text()).toBe("Mar 2021");
+        expect(monthStarts.at(0).element.style.left).toBe("18%");
+        expect(monthStarts.at(1).text()).toBe("Apr 2021");
+        expect(monthStarts.at(1).element.style.left).toBe("80%");
+    });
+
     it("dragging slider updates values", async () => {
         const wrapper = getWrapper();
         // drag second slider back from 05/01/21 to 03/01/21


### PR DESCRIPTION
This branch adds date markers to the lower border of the Phases (Social restrictions) editor, as per the [mockups](https://docs.google.com/presentation/d/1cEwtX94_c3iXJ0uiKe3gM9fFtZKSNzICJE0YAyk5lH0/edit#slide=id.gc9efb13a39_0_230).

It uses the existing method `sliderPosition` to get a left position on the slider width, based on how many days from start of forecast a given date falls. 